### PR TITLE
Pass extra params to auth code request

### DIFF
--- a/src/IdentityModel.OidcClient/AuthorizeClient.cs
+++ b/src/IdentityModel.OidcClient/AuthorizeClient.cs
@@ -80,6 +80,7 @@ namespace IdentityModel.OidcClient
                 State = _crypto.CreateState(),
                 RedirectUri = _options.RedirectUri,
                 CodeVerifier = pkce.CodeVerifier,
+                ExtraParameters = extraParameters
             };
 
             state.StartUrl = CreateUrl(state.State, state.Nonce, pkce.CodeChallenge, extraParameters);

--- a/src/IdentityModel.OidcClient/AuthorizeState.cs
+++ b/src/IdentityModel.OidcClient/AuthorizeState.cs
@@ -40,7 +40,7 @@ namespace IdentityModel.OidcClient
         /// The code verifier.
         /// </value>
         public string CodeVerifier { get; set; }
-        
+
         /// <summary>
         /// Gets or sets the redirect URI.
         /// </summary>
@@ -48,5 +48,13 @@ namespace IdentityModel.OidcClient
         /// The redirect URI.
         /// </value>
         public string RedirectUri { get; set; }
+
+        /// <summary>
+        /// Gets or sets the extra parameters.
+        /// </summary>
+        /// <value>
+        /// The extra parameters.
+        /// </value>
+        public object ExtraParameters { get; set; }
     }
 }

--- a/src/IdentityModel.OidcClient/ResponseProcessor.cs
+++ b/src/IdentityModel.OidcClient/ResponseProcessor.cs
@@ -254,7 +254,8 @@ namespace IdentityModel.OidcClient
             var tokenResult = await client.RequestAuthorizationCodeAsync(
                 code,
                 state.RedirectUri,
-                codeVerifier: state.CodeVerifier);
+                codeVerifier: state.CodeVerifier,
+                extra: state.ExtraParameters);
 
             return tokenResult;
         }


### PR DESCRIPTION
I would like to be able to pass some metadata/context when the Authorization Code is requested.  I can do that with the `extra` params from the `TokenClient`.  Thoughts on something like this for passing the params from the native client?