### PR TITLE
Add support for using Proof of Possession (PoP) when working with Identity Server 3

### DIFF
--- a/src/IdentityModel.OidcClient/OidClientOptions.cs
+++ b/src/IdentityModel.OidcClient/OidClientOptions.cs
@@ -179,6 +179,7 @@ namespace IdentityModel.OidcClient
         /// Gets or sets the ProofOfPossession
         /// </summary>
         /// <remarks>If a Key is set, PoP will be used when obtaining an AccessToken.  Note that this is for use with the Identity Server 3 implementation of the PoP spec</remarks>
+        [Obsolete("Proof of Possession is defined in RFC6750 (https://tools.ietf.org/html/rfc6750), which may be deprecated in favour of oAuth 2.0 Token Binding (https://tools.ietf.org/html/draft-ietf-oauth-token-binding-03).  Only use this if you need to interop with an Identity Server 3 instance that implements PoP (see: https://identityserver.github.io/Documentation/docsv2/pop/overview.html for more information)")]
         public ProofOfPossession ProofOfPossession { get; set; } = new ProofOfPossession();
 
         /// <summary>

--- a/src/IdentityModel.OidcClient/OidClientOptions.cs
+++ b/src/IdentityModel.OidcClient/OidClientOptions.cs
@@ -7,7 +7,6 @@ using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
-using IdentityModel.Jwk;
 
 namespace IdentityModel.OidcClient
 {
@@ -177,10 +176,10 @@ namespace IdentityModel.OidcClient
         public ILoggerFactory LoggerFactory { get; } = new LoggerFactory();
 
         /// <summary>
-        /// Gets or sets the ProofOfPossessionKey
+        /// Gets or sets the ProofOfPossession
         /// </summary>
-        /// <remarks>For use with the Identity Server 3 implementation of the PoP spec</remarks>
-        public JsonWebKey ProofOfPossessionKey { get; set; }
+        /// <remarks>If a Key is set, PoP will be used when obtaining an AccessToken.  Note that this is for use with the Identity Server 3 implementation of the PoP spec</remarks>
+        public ProofOfPossession ProofOfPossession { get; set; } = new ProofOfPossession();
 
         /// <summary>
         /// Gets or sets the claims types that should be filtered.

--- a/src/IdentityModel.OidcClient/OidClientOptions.cs
+++ b/src/IdentityModel.OidcClient/OidClientOptions.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
+using IdentityModel.Jwk;
 
 namespace IdentityModel.OidcClient
 {
@@ -174,6 +175,12 @@ namespace IdentityModel.OidcClient
         /// The logger factory.
         /// </value>
         public ILoggerFactory LoggerFactory { get; } = new LoggerFactory();
+
+        /// <summary>
+        /// Gets or sets the ProofOfPossessionKey
+        /// </summary>
+        /// <remarks>For use with the Identity Server 3 implementation of the PoP spec</remarks>
+        public JsonWebKey ProofOfPossessionKey { get; set; }
 
         /// <summary>
         /// Gets or sets the claims types that should be filtered.

--- a/src/IdentityModel.OidcClient/OidcClient.cs
+++ b/src/IdentityModel.OidcClient/OidcClient.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using IdentityModel.OidcClient.Infrastructure;
 using System.Security.Claims;
 using System.Collections.Generic;
+using IdentityModel.Jwk;
 using Microsoft.Extensions.Logging;
 using IdentityModel.OidcClient.Results;
 using IdentityModel.OidcClient.Browser;
@@ -215,7 +216,16 @@ namespace IdentityModel.OidcClient
 
             await EnsureConfigurationAsync();
             var client = TokenClientFactory.Create(_options);
-            var response = await client.RequestRefreshTokenAsync(refreshToken);
+            TokenResponse response;
+
+            if (_options.ProofOfPossessionKey != null)
+            {
+                response = await client.RequestRefreshTokenPopAsync(refreshToken, _options.ProofOfPossessionKey.Alg, _options.ProofOfPossessionKey.ToJwkString());
+            }
+            else
+            {
+                response = await client.RequestRefreshTokenAsync(refreshToken);
+            }
 
             if (response.IsError)
             {

--- a/src/IdentityModel.OidcClient/OidcClient.cs
+++ b/src/IdentityModel.OidcClient/OidcClient.cs
@@ -218,9 +218,9 @@ namespace IdentityModel.OidcClient
             var client = TokenClientFactory.Create(_options);
             TokenResponse response;
 
-            if (_options.ProofOfPossessionKey != null)
+            if (_options.ProofOfPossession.Key != null)
             {
-                response = await client.RequestRefreshTokenPopAsync(refreshToken, _options.ProofOfPossessionKey.Alg, _options.ProofOfPossessionKey.ToJwkString());
+                response = await client.RequestRefreshTokenPopAsync(refreshToken, _options.ProofOfPossession.Algorithm, _options.ProofOfPossession.JwkString);
             }
             else
             {

--- a/src/IdentityModel.OidcClient/OidcClient.cs
+++ b/src/IdentityModel.OidcClient/OidcClient.cs
@@ -217,7 +217,7 @@ namespace IdentityModel.OidcClient
             await EnsureConfigurationAsync();
             var client = TokenClientFactory.Create(_options);
             TokenResponse response;
-
+#pragma warning disable 618
             if (_options.ProofOfPossession.Key != null)
             {
                 response = await client.RequestRefreshTokenPopAsync(refreshToken, _options.ProofOfPossession.Algorithm, _options.ProofOfPossession.JwkString);
@@ -226,6 +226,7 @@ namespace IdentityModel.OidcClient
             {
                 response = await client.RequestRefreshTokenAsync(refreshToken);
             }
+#pragma warning restore 618
 
             if (response.IsError)
             {

--- a/src/IdentityModel.OidcClient/ProofOfPossession.cs
+++ b/src/IdentityModel.OidcClient/ProofOfPossession.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+
+using IdentityModel.Jwk;
+
+namespace IdentityModel.OidcClient
+{
+    /// <summary>
+    /// Information about a ProofOfPossession Key
+    /// </summary>
+    public class ProofOfPossession
+    {
+        /// <summary>
+        /// Gets or sets the Key to use for proving possession of tokens
+        /// </summary>
+        public JsonWebKey Key { get; set; }
+
+        /// <summary>
+        /// Gets the string version of the Key
+        /// </summary>
+        public string JwkString => Key?.ToJwkString();
+
+        /// <summary>
+        /// Gets the algorithm used to create the Key
+        /// </summary>
+        public string Algorithm => Key?.Alg;
+    }
+}

--- a/src/IdentityModel.OidcClient/ResponseProcessor.cs
+++ b/src/IdentityModel.OidcClient/ResponseProcessor.cs
@@ -252,14 +252,14 @@ namespace IdentityModel.OidcClient
 
             var client = GetTokenClient();
 
-            if (_options.ProofOfPossessionKey != null)
+            if (_options.ProofOfPossession.Key != null)
             {
                 var popTokenResult = await client.RequestAuthorizationCodePopAsync(
                     code,
                     state.RedirectUri,
                     state.CodeVerifier,
-                    _options.ProofOfPossessionKey.Alg,
-                    _options.ProofOfPossessionKey.ToJwkString()
+                    _options.ProofOfPossession.Algorithm,
+                    _options.ProofOfPossession.JwkString
                     );
 
                 return popTokenResult;

--- a/src/IdentityModel.OidcClient/ResponseProcessor.cs
+++ b/src/IdentityModel.OidcClient/ResponseProcessor.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Logging;
 using System;
 using System.Security.Claims;
 using System.Threading.Tasks;
+using IdentityModel.Jwk;
 
 namespace IdentityModel.OidcClient
 {
@@ -251,12 +252,27 @@ namespace IdentityModel.OidcClient
 
             var client = GetTokenClient();
 
-            var tokenResult = await client.RequestAuthorizationCodeAsync(
-                code,
-                state.RedirectUri,
-                codeVerifier: state.CodeVerifier);
+            if (_options.ProofOfPossessionKey != null)
+            {
+                var popTokenResult = await client.RequestAuthorizationCodePopAsync(
+                    code,
+                    state.RedirectUri,
+                    state.CodeVerifier,
+                    _options.ProofOfPossessionKey.Alg,
+                    _options.ProofOfPossessionKey.ToJwkString()
+                    );
 
-            return tokenResult;
+                return popTokenResult;
+            }
+            else
+            {
+                var tokenResult = await client.RequestAuthorizationCodeAsync(
+                    code,
+                    state.RedirectUri,
+                    codeVerifier: state.CodeVerifier);
+
+                return tokenResult;
+            }
         }
 
         private TokenClient GetTokenClient()

--- a/src/IdentityModel.OidcClient/ResponseProcessor.cs
+++ b/src/IdentityModel.OidcClient/ResponseProcessor.cs
@@ -251,7 +251,7 @@ namespace IdentityModel.OidcClient
             _logger.LogTrace("RedeemCodeAsync");
 
             var client = GetTokenClient();
-
+#pragma warning disable 618
             if (_options.ProofOfPossession.Key != null)
             {
                 var popTokenResult = await client.RequestAuthorizationCodePopAsync(
@@ -273,6 +273,7 @@ namespace IdentityModel.OidcClient
 
                 return tokenResult;
             }
+#pragma warning restore 618
         }
 
         private TokenClient GetTokenClient()


### PR DESCRIPTION
Pull Request to go with #31 

I understand that the PoP spec may never be finished, but there is an implementation in Identity Server 3, and the IdentityModel2 TokenClient has extension methods that use it.  It makes sense to me to also add that support in OidcClient2.

This is the simplest/lightest change I could think of to add the functionality.  Note that JsonWebKey was used as we have a NetStandard implementation of it and it can easily be created from platform-specific cryptographic functions like RSACryptoServiceProvider (this could be reviewed when NetStandard 2.0 arrives)