### PR TITLE
Added inner HTTP handler for RefreshTokenHandler to OidClientOptions

### DIFF
--- a/src/IdentityModel.OidcClient/OidClientOptions.cs
+++ b/src/IdentityModel.OidcClient/OidClientOptions.cs
@@ -136,6 +136,14 @@ namespace IdentityModel.OidcClient
         public AuthenticationFlow Flow { get; set; } = AuthenticationFlow.Hybrid;
 
         /// <summary>
+        /// Gets or sets the inner HTTP handler used with RefreshTokenHandler.
+        /// </summary>
+        /// <value>
+        /// The handler.
+        /// </value>
+        public HttpMessageHandler RefreshTokenInnerHttpHandler { get; set; } = new HttpClientHandler();
+
+        /// <summary>
         /// Gets or sets the HTTP handler used for back-channel communication (token and userinfo endpoint).
         /// </summary>
         /// <value>
@@ -193,6 +201,7 @@ namespace IdentityModel.OidcClient
             JwtClaimTypes.AuthorizationCodeHash,
             JwtClaimTypes.AccessTokenHash
         };
+
 
         /// <summary>
         /// The authentication flows

--- a/src/IdentityModel.OidcClient/OidcClient.cs
+++ b/src/IdentityModel.OidcClient/OidcClient.cs
@@ -167,7 +167,8 @@ namespace IdentityModel.OidcClient
                 loginResult.RefreshTokenHandler = new RefreshTokenHandler(
                     TokenClientFactory.Create(_options),
                     loginResult.RefreshToken,
-                    loginResult.AccessToken);
+                    loginResult.AccessToken,
+                    _options.RefreshTokenInnerHttpHandler);
             }
 
             return loginResult;


### PR DESCRIPTION
We need to provide our own HttpMessageHandler as inner handler to the RefreshtokenHandler. This is for us to be able to set MaxConnectionsPerServer due to some strange blocking behavior on token refresh. I am still looking into the reasons for the blocking, but nonetheless I believe bringing your own HttpMessageHandler is always a nice option.