### PR TITLE
Changed result to refreshResult to check for RefreshTokenAsync result

### DIFF
--- a/clients/ConsoleClientWithBrowser/Program.cs
+++ b/clients/ConsoleClientWithBrowser/Program.cs
@@ -100,7 +100,7 @@ namespace ConsoleClientWithBrowser
                 if (key.Key == ConsoleKey.R)
                 {
                     var refreshResult = await _oidcClient.RefreshTokenAsync(currentRefreshToken);
-                    if (result.IsError)
+                    if (refreshResult.IsError)
                     {
                         Console.WriteLine($"Error: {refreshResult.Error}");
                     }


### PR DESCRIPTION
I think, in `NextSteps` function we should be checking the errors in `refreshResult` instead of `result` variable.