### PR TITLE
Disable validation on Issuer on JWT token

### DIFF
--- a/src/IdentityModel.OidcClient/IdentityTokenValidator.cs
+++ b/src/IdentityModel.OidcClient/IdentityTokenValidator.cs
@@ -40,7 +40,7 @@ namespace IdentityModel.OidcClient
             {
                 ValidIssuer = _options.ProviderInformation.IssuerName,
                 ValidAudience = _options.ClientId,
-
+                ValidateIssuer = _options.Policy.Discovery.ValidateIssuerName,
                 NameClaimType = JwtClaimTypes.Name,
                 RoleClaimType = JwtClaimTypes.Role,
 

--- a/src/IdentityModel.OidcClient/IdentityTokenValidator.cs
+++ b/src/IdentityModel.OidcClient/IdentityTokenValidator.cs
@@ -40,7 +40,7 @@ namespace IdentityModel.OidcClient
             {
                 ValidIssuer = _options.ProviderInformation.IssuerName,
                 ValidAudience = _options.ClientId,
-                ValidateIssuer = _options.Policy.Discovery.ValidateIssuerName,
+                ValidateIssuer = _options.Policy.ValidateTokenIssuerName,
                 NameClaimType = JwtClaimTypes.Name,
                 RoleClaimType = JwtClaimTypes.Role,
 

--- a/src/IdentityModel.OidcClient/Policy.cs
+++ b/src/IdentityModel.OidcClient/Policy.cs
@@ -53,6 +53,12 @@ namespace IdentityModel.OidcClient
         public bool RequireIdentityTokenSignature { get; set; } = true;
 
         /// <summary>
+        /// Gets or sets a value indicating whether the identity token issuer name should match.
+        /// </summary>
+        /// <value><c>true</c> if identity token issuer name should match; otherwise, <c>false</c>.</value>
+        public bool ValidateTokenIssuerName { get; set; } = true;
+
+        /// <summary>
         /// Gets or sets the supported identity token signing algorithms.
         /// </summary>
         /// <value>


### PR DESCRIPTION
This is necessary in order to get the client to work with Microsoft Authentication service. (https://login.microsoftonline.com/common/.well-known/openid-configuration)

Since the /common endpoint doesn’t correspond to a tenant and isn’t an issuer, when you examine the issuer value in the metadata for /common it has a templated URL instead of an actual value : https://sts.windows.net/{tenantid}/

Therefore, a multi-tenant application can’t validate tokens just by matching the issuer value in the metadata with the issuer value in the token. A multi-tenant application needs logic to decide which issuer values are valid and which are not, based on the tenant ID portion of the issuer value.

Since we already need to set the property Discovery.ValidateIssuerName to false for the same reasons it would be safe to say we can use the same property to disable the Issuer check in the IdentityToken


