### PR TITLE
Add net47 target

### DIFF
--- a/src/IdentityModel.OidcClient/IdentityModel.OidcClient.csproj
+++ b/src/IdentityModel.OidcClient/IdentityModel.OidcClient.csproj
@@ -4,7 +4,7 @@
     <VersionPrefix>2.6.0</VersionPrefix>
     <!--<VersionSuffix>preview-1</VersionSuffix>-->
     <Authors>Dominick Baier;Brock Allen</Authors>
-    <TargetFrameworks>net452;netstandard1.4;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net452;net47;netstandard1.4;netstandard2.0</TargetFrameworks>
     <AssemblyName>IdentityModel.OidcClient</AssemblyName>
     <PackageId>IdentityModel.OidcClient</PackageId>
     <PackageTags>OAuth2;OAuth 2.0;OpenID Connect;Security;Identity;IdentityServer</PackageTags>
@@ -34,4 +34,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.2" />
   </ItemGroup>
 
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net47' ">
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.0" />
+  </ItemGroup>
 </Project>

--- a/src/IdentityModel.OidcClient/IdentityModel.OidcClient.csproj
+++ b/src/IdentityModel.OidcClient/IdentityModel.OidcClient.csproj
@@ -35,6 +35,6 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net47' ">
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.2" />
   </ItemGroup>
 </Project>

--- a/test/IdentityModel.OidcClient.Tests/IdentityModel.OidcClient.Tests.csproj
+++ b/test/IdentityModel.OidcClient.Tests/IdentityModel.OidcClient.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net452;net461;netcoreapp1.1;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net452;net461;net47;netcoreapp1.1;netcoreapp2.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Keeping the oidc client library in sync with the targets for the common identity model library.