### PR TITLE
Allow LogSerializer to be disabled to facilitate usage in Unity iOS

### DIFF
--- a/src/IdentityModel.OidcClient/Infrastructure/LogSerializer.cs
+++ b/src/IdentityModel.OidcClient/Infrastructure/LogSerializer.cs
@@ -8,6 +8,10 @@ namespace IdentityModel.OidcClient.Infrastructure
     /// </summary>
     public static class LogSerializer
     {
+        /// <summary>
+        /// Allows log serialization to be disabled, for example, for platforms
+        /// that don't support serialization of arbitarary objects to JSON.
+        /// </summary>
         public static bool Enabled = true;
 
         static readonly JsonSerializerSettings jsonSettings = new JsonSerializerSettings
@@ -29,7 +33,7 @@ namespace IdentityModel.OidcClient.Infrastructure
         /// <returns></returns>
         public static string Serialize(object logObject)
         {
-            return Enabled ? JsonConvert.SerializeObject(logObject, jsonSettings) : "";
+            return Enabled ? JsonConvert.SerializeObject(logObject, jsonSettings) : "Logging has been disabled";
         }
     }
 }

--- a/src/IdentityModel.OidcClient/Infrastructure/LogSerializer.cs
+++ b/src/IdentityModel.OidcClient/Infrastructure/LogSerializer.cs
@@ -6,8 +6,10 @@ namespace IdentityModel.OidcClient.Infrastructure
     /// <summary>
     /// Helper to JSON serialize object data for logging.
     /// </summary>
-    internal static class LogSerializer
+    public static class LogSerializer
     {
+        public static bool Enabled = true;
+
         static readonly JsonSerializerSettings jsonSettings = new JsonSerializerSettings
         {
             NullValueHandling = NullValueHandling.Ignore,
@@ -27,7 +29,7 @@ namespace IdentityModel.OidcClient.Infrastructure
         /// <returns></returns>
         public static string Serialize(object logObject)
         {
-            return JsonConvert.SerializeObject(logObject, jsonSettings);
+            return Enabled ? JsonConvert.SerializeObject(logObject, jsonSettings) : "";
         }
     }
 }


### PR DESCRIPTION
Unity iOS apps using the Unity equivalent of NewtonSoft.Json library crash when trying to JSON serialize objects with properties.  This PR is to add a mechanism to disable the serialization of arbitrary objects for logging purposes, which is the only code change required to have this library working in Unity iOS apps.