### PR TITLE
Add DateTime property to refresh result similiar to LoginResult

### DIFF
--- a/src/IdentityModel.OidcClient/OidcClient.cs
+++ b/src/IdentityModel.OidcClient/OidcClient.cs
@@ -307,7 +307,8 @@ namespace IdentityModel.OidcClient
                 IdentityToken = response.IdentityToken,
                 AccessToken = response.AccessToken,
                 RefreshToken = response.RefreshToken,
-                ExpiresIn = (int)response.ExpiresIn
+                ExpiresIn = (int)response.ExpiresIn,
+                AccessTokenExpiration = DateTime.Now.AddSeconds(response.ExpiresIn)
             };
         }
 

--- a/src/IdentityModel.OidcClient/Results/RefreshTokenResult.cs
+++ b/src/IdentityModel.OidcClient/Results/RefreshTokenResult.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
+using System;
+
 namespace IdentityModel.OidcClient.Results
 {
     /// <summary>
@@ -41,5 +43,14 @@ namespace IdentityModel.OidcClient.Results
         /// The expires in.
         /// </value>
         public virtual int ExpiresIn { get; internal set; }
+        
+        /// <summary>
+        /// Gets or sets the access token expiration.
+        /// </summary>
+        /// <value>
+        /// The access token expiration.
+        /// </value>
+        public virtual DateTime AccessTokenExpiration { get; internal set; }
+
     }
 }


### PR DESCRIPTION
Following from the implemetation of the LoginResult. It would be nice if the RefreshResult also had a DataTime object for AccessTokenExpiration.