### PR TITLE
webkey property specifying 'use' is optional according to the spec

### DIFF
--- a/src/IdentityModel.OidcClient/IdentityTokenValidator.cs
+++ b/src/IdentityModel.OidcClient/IdentityTokenValidator.cs
@@ -163,7 +163,7 @@ namespace IdentityModel.OidcClient
                     if (webKey.E.IsPresent() && webKey.N.IsPresent())
                     {
                         // only add keys used for signatures
-                        if (webKey.Use == "sig")
+                        if (webKey.Use == "sig" || webKey.Use == null)
                         {
                             var e = Base64Url.Decode(webKey.E);
                             var n = Base64Url.Decode(webKey.N);


### PR DESCRIPTION
While implementing OIDC Client, I encountered a provider that did not specify "use":"sig" for their webkey.

My first course of action was to approach the IdP and submit a bug that they would add this property, but according to the spec, it is optional.

This code change allows a web key to be used for signatures if the "Use" is not specified.