### PR TITLE
Output refreshed tokens to Console in sample application

### DIFF
--- a/clients/ConsoleClientWithBrowser/Program.cs
+++ b/clients/ConsoleClientWithBrowser/Program.cs
@@ -110,8 +110,8 @@ namespace ConsoleClientWithBrowser
                         currentAccessToken = refreshResult.AccessToken;
 
                         Console.WriteLine("\n\n");
-                        Console.WriteLine($"access token:   {result.AccessToken}");
-                        Console.WriteLine($"refresh token:  {result?.RefreshToken ?? "none"}");
+                        Console.WriteLine($"access token:   {currentAccessToken}");
+                        Console.WriteLine($"refresh token:  {currentRefreshToken ?? "none"}");
                     }
                 }
             }


### PR DESCRIPTION
Fixed an issue where the `ConsoleClientWithBrowser` sample outputs the original tokens to Console after triggering a refresh (#91).