### PR TITLE
IdentityModel.Tokens.Jwt < 5.3.0

### DIFF
--- a/src/IdentityModel.OidcClient.csproj
+++ b/src/IdentityModel.OidcClient.csproj
@@ -24,7 +24,7 @@
 
   <ItemGroup>
     <PackageReference Include="IdentityModel" Version="3.10.0" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.2.1" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="[5.2.1,5.3.0)" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.4' ">


### PR DESCRIPTION
To prevent error "Error validating identity token: Microsoft.IdentityModel.Tokens.SecurityTokenSignatureKeyNotFoundException: IDX10501: Signature validation failed. Unable to match keys …."

While [this](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/issues/1067) is closed, even Android has this issue