### PR TITLE
The TokenResponse delivered by the server is captured and delivered to the client via LoginResult.

### DIFF
--- a/clients/ConformanceTests/Helper.cs
+++ b/clients/ConformanceTests/Helper.cs
@@ -1,7 +1,9 @@
 ﻿using IdentityModel.Client;
 using IdentityModel.OidcClient;
+using Newtonsoft.Json;
 using Serilog;
 using System;
+using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
 
@@ -72,6 +74,14 @@ namespace ConformanceTests
                 {
                     Console.WriteLine($"\nRefresh token:\n{result.RefreshToken}");
                 }
+
+                Console.WriteLine($"Logging Raw TokenResponse...");
+                var values = JsonConvert.DeserializeObject<Dictionary<string, string>>(result.TokenResponse.Raw);
+                foreach (var item in values)
+                {
+                    Console.WriteLine($"{item.Key}: {item.Value}");
+                }
+
             }
         }
 

--- a/clients/ConsoleClient/Program.cs
+++ b/clients/ConsoleClient/Program.cs
@@ -1,7 +1,9 @@
 ﻿using IdentityModel.OidcClient;
 using Microsoft.Net.Http.Server;
+using Newtonsoft.Json;
 using Serilog;
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
@@ -101,6 +103,15 @@ namespace ConsoleClient
             Console.WriteLine($"\nidentity token: {result.IdentityToken}");
             Console.WriteLine($"access token:   {result.AccessToken}");
             Console.WriteLine($"refresh token:  {result?.RefreshToken ?? "none"}");
+
+            var values = JsonConvert.DeserializeObject<Dictionary<string, string>>(result.TokenResponse.Raw);
+
+            Console.WriteLine($"Raw TokenResponse ...");
+            foreach (var item in values)
+            {
+                Console.WriteLine($"{item.Key}: {item.Value}");
+            }
+
         }
 
         private static async Task SendResponseAsync(Response response)

--- a/clients/ConsoleClientWithBrowser/Program.cs
+++ b/clients/ConsoleClientWithBrowser/Program.cs
@@ -1,7 +1,9 @@
 ﻿using IdentityModel.OidcClient;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Serilog;
 using System;
+using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
 
@@ -85,6 +87,14 @@ namespace ConsoleClientWithBrowser
             Console.WriteLine($"\nidentity token: {result.IdentityToken}");
             Console.WriteLine($"access token:   {result.AccessToken}");
             Console.WriteLine($"refresh token:  {result?.RefreshToken ?? "none"}");
+
+            var values = JsonConvert.DeserializeObject<Dictionary<string, string>>(result.TokenResponse.Raw);
+
+            Console.WriteLine($"Raw TokenResponse ...");
+            foreach (var item in values)
+            {
+                Console.WriteLine($"{item.Key}: {item.Value}");
+            }
         }
 
         private static async Task NextSteps(LoginResult result)

--- a/src/OidcClient.cs
+++ b/src/OidcClient.cs
@@ -222,7 +222,8 @@ namespace IdentityModel.OidcClient
                 RefreshToken = result.TokenResponse.RefreshToken,
                 AccessTokenExpiration = DateTime.Now.AddSeconds(result.TokenResponse.ExpiresIn),
                 IdentityToken = result.TokenResponse.IdentityToken,
-                AuthenticationTime = DateTime.Now
+                AuthenticationTime = DateTime.Now,
+                TokenResponse = result.TokenResponse // In some cases there is additional custom response data that clients need access to
             };
 
             if (loginResult.RefreshToken.IsPresent())

--- a/src/Results/LoginResult.cs
+++ b/src/Results/LoginResult.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Net.Http;
 using System.Security.Claims;
+using IdentityModel.Client;
 
 namespace IdentityModel.OidcClient
 {
@@ -85,5 +86,13 @@ namespace IdentityModel.OidcClient
         /// The refresh token handler.
         /// </value>
         public virtual DelegatingHandler RefreshTokenHandler { get; internal set; }
+        
+        /// <summary>
+        /// Gets or sets the TokenResponse.
+        /// </summary>
+        /// <value>
+        /// The token response from the server.
+        /// </value>
+        public TokenResponse TokenResponse { get; internal set; }
     }
 }

--- a/test/IdentityModel.OidcClient.Tests/HybridFlowResponseTests.cs
+++ b/test/IdentityModel.OidcClient.Tests/HybridFlowResponseTests.cs
@@ -83,6 +83,7 @@ namespace IdentityModel.OidcClient.Tests
             result.AccessToken.Should().Be("token");
             result.IdentityToken.Should().NotBeNull();
             result.User.Should().NotBeNull();
+            result.TokenResponse.Should().NotBeNull();
         }
 
         [Fact]
@@ -128,6 +129,8 @@ namespace IdentityModel.OidcClient.Tests
             result.AccessToken.Should().Be("token");
             result.IdentityToken.Should().NotBeNull();
             result.User.Should().NotBeNull();
+            result.TokenResponse.Should().NotBeNull();
+
 
             var body = handler.Body;
             body.Should().Contain("foo=foo");
@@ -245,6 +248,8 @@ namespace IdentityModel.OidcClient.Tests
                 result.AccessToken.Should().Be("token");
                 result.IdentityToken.Should().NotBeNull();
                 result.User.Should().NotBeNull();
+                result.TokenResponse.Should().NotBeNull();
+
             }
         }
 


### PR DESCRIPTION
The primary reason is that it is OK for the server to send additional custom data along with the required OIDC specified must have responses.

ref: https://github.com/IdentityModel/IdentityModel.OidcClient2/issues/142