### PR TITLE
Add `ErrorDescription` to result of `RefreshTokenAsync` error

### DIFF
--- a/src/OidcClient.cs
+++ b/src/OidcClient.cs
@@ -320,7 +320,11 @@ namespace IdentityModel.OidcClient
 
             if (response.IsError)
             {
-                return new RefreshTokenResult { Error = response.Error };
+                return new RefreshTokenResult
+                {
+                    Error = response.Error,
+                    ErrorDescription = response.ErrorDescription,
+                };
             }
 
             // validate token response

--- a/src/Results/Result.cs
+++ b/src/Results/Result.cs
@@ -24,5 +24,13 @@ namespace IdentityModel.OidcClient
         /// The error.
         /// </value>
         public virtual string Error { get; set; }
+
+        /// <summary>
+        /// Gets or sets the error description.
+        /// </summary>
+        /// <value>
+        /// The error description.
+        /// </value>
+        public virtual string ErrorDescription { get; set; }
     }
 }


### PR DESCRIPTION
The `response.ErrorDescription` contains additional info to the `response.Error`. This is very valuable especially since `invalid_grant` error is a bucket for a number of errors. For example "invalid refresh token", "refresh token expired", "server clock out of sync".

Refer to [this post](https://stackoverflow.com/questions/10576386/invalid-grant-trying-to-get-oauth-token-from-google) for more examples of what an `invalid_grant` error could be.

This change was tested locally and does indeed allow us (as a consumer of this OIDC library) to get access to the ErrorDescription, which in our case is an "Invalid refresh token" error. Without this fix we only get `invalid_grant` with no additional information.