### PR TITLE
Add support for ClientAssertion client auth

### DIFF
--- a/src/OidcClient/OidcClient.cs
+++ b/src/OidcClient/OidcClient.cs
@@ -313,6 +313,7 @@ namespace IdentityModel.OidcClient
                 Address = Options.ProviderInformation.TokenEndpoint,
                 ClientId = Options.ClientId,
                 ClientSecret = Options.ClientSecret,
+                ClientAssertion = Options.ClientAssertion,
                 ClientCredentialStyle = Options.TokenClientCredentialStyle,
                 RefreshToken = refreshToken, 
                 Parameters = extraParameters ?? new Dictionary<string, string>()

--- a/src/OidcClient/OidcClientOptions.cs
+++ b/src/OidcClient/OidcClientOptions.cs
@@ -50,6 +50,14 @@ namespace IdentityModel.OidcClient
         public string ClientSecret { get; set; }
 
         /// <summary>
+        /// Gets or sets the client assertion (if needed).
+        /// </summary>
+        /// <value>
+        /// The client assertion.
+        /// </value>
+        public ClientAssertion ClientAssertion { get; set; } = new ClientAssertion();
+
+        /// <summary>
         /// Gets or sets the scopes (required).
         /// </summary>
         /// <value>

--- a/src/OidcClient/ResponseProcessor.cs
+++ b/src/OidcClient/ResponseProcessor.cs
@@ -199,6 +199,7 @@ namespace IdentityModel.OidcClient
 
                 ClientId = _options.ClientId,
                 ClientSecret = _options.ClientSecret,
+                ClientAssertion = _options.ClientAssertion,
                 ClientCredentialStyle = _options.TokenClientCredentialStyle,
 
                 Code = code,


### PR DESCRIPTION
Small change that enables support for authenticating clients with assertions when calling the token endpoint (when exchanging the auth code & when refreshing tokens). 