### PR TITLE
Fill ErrorDescription property for LoginResult

### DIFF
--- a/src/OidcClient/OidcClient.cs
+++ b/src/OidcClient/OidcClient.cs
@@ -79,7 +79,7 @@ namespace IdentityModel.OidcClient
             
             if (authorizeResult.IsError)
             {
-                return new LoginResult(authorizeResult.Error);
+                return new LoginResult(authorizeResult.Error, authorizeResult.ErrorDescription);
             }
 
             var result = await ProcessResponseAsync(
@@ -182,14 +182,14 @@ namespace IdentityModel.OidcClient
             if (authorizeResponse.IsError)
             {
                 _logger.LogError(authorizeResponse.Error);
-                return new LoginResult(authorizeResponse.Error);
+                return new LoginResult(authorizeResponse.Error, authorizeResponse.ErrorDescription);
             }
 
             var result = await _processor.ProcessResponseAsync(authorizeResponse, state, extraParameters, cancellationToken);
             if (result.IsError)
             {
                 _logger.LogError(result.Error);
-                return new LoginResult(result.Error);
+                return new LoginResult(result.Error, result.ErrorDescription);
             }
 
             var userInfoClaims = Enumerable.Empty<Claim>();

--- a/src/OidcClient/Results/LoginResult.cs
+++ b/src/OidcClient/Results/LoginResult.cs
@@ -32,6 +32,17 @@ namespace IdentityModel.OidcClient
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="LoginResult"/> class.
+        /// </summary>
+        /// <param name="error">The error.</param>
+        /// <param name="errorDescription">The error description.</param>
+        public LoginResult(string error, string errorDescription)
+        {
+            Error = error;
+            ErrorDescription = errorDescription;
+        }
+
+        /// <summary>
         /// Gets or sets the user.
         /// </summary>
         /// <value>


### PR DESCRIPTION
Fixes issue #268 
The error description is now propagated from the authorize and token response to the LoginResult instance