### PR TITLE
WIP Fix/277

### DIFF
--- a/src/OidcClient/OidcClient.cs
+++ b/src/OidcClient/OidcClient.cs
@@ -5,7 +5,9 @@
 using IdentityModel.Client;
 using IdentityModel.OidcClient.Infrastructure;
 using IdentityModel.OidcClient.Results;
+
 using Microsoft.Extensions.Logging;
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -77,7 +79,7 @@ namespace IdentityModel.OidcClient
                 Timeout = request.BrowserTimeout,
                 ExtraParameters = request.FrontChannelExtraParameters
             }, cancellationToken);
-            
+
             if (authorizeResult.IsError)
             {
                 return new LoginResult(authorizeResult.Error, authorizeResult.ErrorDescription);
@@ -235,6 +237,7 @@ namespace IdentityModel.OidcClient
             DateTimeOffset? authTime = null;
             if (authTimeValue.IsPresent() && long.TryParse(authTimeValue, out seconds))
                 authTime = new DateTimeOffset(TOKEN_START_TIME, TimeSpan.Zero).AddSeconds(seconds);
+
             var loginResult = new LoginResult
             {
                 User = user,
@@ -313,7 +316,7 @@ namespace IdentityModel.OidcClient
 
             await EnsureConfigurationAsync(cancellationToken);
             var client = Options.CreateClient();
-            
+
             var response = await client.RequestRefreshTokenAsync(new RefreshTokenRequest
             {
                 Address = Options.ProviderInformation.TokenEndpoint,
@@ -383,11 +386,11 @@ namespace IdentityModel.OidcClient
                     Address = Options.Authority,
                     Policy = Options.Policy.Discovery
                 }, cancellationToken).ConfigureAwait(false);
-               
+
                 if (disco.IsError)
                 {
                     _logger.LogError("Error loading discovery document: {errorType} - {error}", disco.ErrorType.ToString(), disco.Error);
-                    
+
                     if (disco.ErrorType == ResponseErrorType.Exception)
                     {
                         throw new InvalidOperationException("Error loading discovery document: " + disco.Error, disco.Exception);

--- a/src/OidcClient/OidcClient.cs
+++ b/src/OidcClient/OidcClient.cs
@@ -350,8 +350,8 @@ namespace IdentityModel.OidcClient
                 IdentityToken = response.IdentityToken,
                 AccessToken = response.AccessToken,
                 RefreshToken = response.RefreshToken,
-                ExpiresIn = (int)response.ExpiresIn,
-                AccessTokenExpiration = DateTime.Now.AddSeconds(response.ExpiresIn)
+                ExpiresIn = response.ExpiresIn,
+                AccessTokenExpiration = DateTimeOffset.Now.AddSeconds(response.ExpiresIn)
             };
         }
 

--- a/src/OidcClient/Results/LoginResult.cs
+++ b/src/OidcClient/Results/LoginResult.cs
@@ -88,7 +88,7 @@ namespace IdentityModel.OidcClient
         /// <value>
         /// The authentication time.
         /// </value>
-        public virtual DateTimeOffset AuthenticationTime { get; internal set; }
+        public virtual DateTimeOffset? AuthenticationTime { get; internal set; }
 
         /// <summary>
         /// Gets or sets the refresh token handler.

--- a/src/OidcClient/Results/RefreshTokenResult.cs
+++ b/src/OidcClient/Results/RefreshTokenResult.cs
@@ -50,7 +50,7 @@ namespace IdentityModel.OidcClient.Results
         /// <value>
         /// The access token expiration.
         /// </value>
-        public virtual DateTime AccessTokenExpiration { get; internal set; }
+        public virtual DateTimeOffset AccessTokenExpiration { get; internal set; }
 
     }
 }


### PR DESCRIPTION
fixes #277 

- Gets the authentication time from the token instead of now, if possible.  If not possible, then return nulll DateTimeOffset?.  
- Make RefreshTokenResult also use DateTimeOffset