### PR TITLE
Test & Fix for issue #266: Refresh tokens with sliding refresh tokens

### DIFF
--- a/src/OidcClient/RefreshTokenDelegatingHandler.cs
+++ b/src/OidcClient/RefreshTokenDelegatingHandler.cs
@@ -156,17 +156,16 @@ namespace IdentityModel.OidcClient
 
         private async Task<bool> RefreshTokensAsync(CancellationToken cancellationToken)
         {
-            var refreshToken = RefreshToken;
-            if (refreshToken.IsMissing())
-            {
-                return false;
-            }
-
             if (await _lock.WaitAsync(Timeout, cancellationToken).ConfigureAwait(false))
             {
+                if (_refreshToken.IsMissing())
+                {
+                    return false;
+                }
+
                 try
                 {
-                    var response = await _oidcClient.RefreshTokenAsync(refreshToken, cancellationToken: cancellationToken).ConfigureAwait(false);
+                    var response = await _oidcClient.RefreshTokenAsync(_refreshToken, cancellationToken: cancellationToken).ConfigureAwait(false);
 
                     if (!response.IsError)
                     {

--- a/src/OidcClient/RefreshTokenDelegatingHandler.cs
+++ b/src/OidcClient/RefreshTokenDelegatingHandler.cs
@@ -156,16 +156,17 @@ namespace IdentityModel.OidcClient
 
         private async Task<bool> RefreshTokensAsync(CancellationToken cancellationToken)
         {
+            var refreshToken = RefreshToken;
+            if (refreshToken.IsMissing())
+            {
+                return false;
+            }
+
             if (await _lock.WaitAsync(Timeout, cancellationToken).ConfigureAwait(false))
             {
-                if (_refreshToken.IsMissing())
-                {
-                    return false;
-                }
-
                 try
                 {
-                    var response = await _oidcClient.RefreshTokenAsync(_refreshToken, cancellationToken: cancellationToken).ConfigureAwait(false);
+                    var response = await _oidcClient.RefreshTokenAsync(refreshToken, cancellationToken: cancellationToken).ConfigureAwait(false);
 
                     if (!response.IsError)
                     {

--- a/test/OidcClient.Tests/RefreshTokenDelegatingHandlerTests.cs
+++ b/test/OidcClient.Tests/RefreshTokenDelegatingHandlerTests.cs
@@ -54,7 +54,7 @@ namespace IdentityModel.OidcClient.Tests
         public async Task Can_refresh_access_tokens_in_parallel()
         {
             var logicalThreadCount = 10;
-            var callsPerThread = 1000;
+            var callsPerThread = 10;
             var maxCallsPerAccessToken = 20;
 
             var tokens = new TestTokens(maxCallsPerAccessToken);
@@ -95,17 +95,21 @@ namespace IdentityModel.OidcClient.Tests
 
             public async Task SecuredPing()
             {
+                int n = 0;
+
                 // Had to relax the test, since it is perfectly possible that 
                 // a single retry by the refresh handler is not enough.
                 // The test needs to demonstrate that we can recover from 
                 // expired access tokens without a new login (so just by using the refresh token).
-                while (true)
+                while (++n < 100)
                 {
                     var response = await _client.GetAsync("/whatever");
 
                     if (response.IsSuccessStatusCode)
                         return;
                 }
+
+                throw new Exception("The client was not able to recover.");
             }
 
             public void Dispose()

--- a/test/OidcClient.Tests/RefreshTokenDelegatingHandlerTests.cs
+++ b/test/OidcClient.Tests/RefreshTokenDelegatingHandlerTests.cs
@@ -1,0 +1,190 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using IdentityModel.Client;
+using IdentityModel.OidcClient.Results;
+using Xunit;
+
+namespace IdentityModel.OidcClient.Tests
+{
+    public class RefreshTokenDelegatingHandlerTests
+    {
+        [Fact]
+        public async Task Can_refresh_access_tokens_with_sliding_refresh_tokens()
+        {
+            const int maxCallsPerAccessToken = 2;
+
+            var tokens = new TestTokens(maxCallsPerAccessToken);
+
+            var handlerUnderTest = new RefreshTokenDelegatingHandler(
+                new TestableOidcTokenRefreshClient(tokens), tokens.InitialAccessToken, tokens.InitialRefreshToken,
+                new TestServer(tokens));
+
+            using (var client = new TestClient(handlerUnderTest))
+            {
+                tokens.Count.Should().Be(1);
+                await client.SecuredPing();
+                tokens.Count.Should().Be(1);
+                await client.SecuredPing();
+                tokens.Count.Should().Be(1);
+                await client.SecuredPing();
+                tokens.Count.Should().Be(2);
+            }
+        }
+
+        private class TestClient : IDisposable
+        {
+            private readonly HttpClient _client;
+
+            public TestClient(RefreshTokenDelegatingHandler refreshTokenHandler)
+            {
+                _client = new HttpClient(refreshTokenHandler)
+                {
+                    BaseAddress = new Uri("http://testing")
+                };
+            }
+
+            public async Task SecuredPing()
+            {
+                await _client.GetAsync("/whatever");
+            }
+
+            public void Dispose()
+            {
+                _client.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// Simulates access tokens with sliding expiration tokens.
+        /// The important bit being that the refresh token gets invalidated after each access token refresh.
+        /// Expiration is simulated by counting access token usage instead of time-based expiration. (see <see cref="_maxCallsPerAccessToken"/> and <see cref="TokenSet.AccessTokenUseCount"/>)
+        /// </summary>
+        private class TestTokens
+        {
+            private readonly int _maxCallsPerAccessToken;
+            private readonly ConcurrentStack<TokenSet> _tokens;
+
+            public TestTokens(int maxCallsPerAccessToken)
+            {
+                _maxCallsPerAccessToken = maxCallsPerAccessToken;
+
+                var initialTokenSet = new TokenSet();
+
+                InitialAccessToken = initialTokenSet.AccessToken;
+                InitialRefreshToken = initialTokenSet.RefreshToken;
+
+                _tokens = new ConcurrentStack<TokenSet>();
+                _tokens.Push(initialTokenSet);
+            }
+
+            public string InitialAccessToken { get; }
+            public string InitialRefreshToken { get; }
+            public int Count => _tokens.Count;
+
+            internal class TokenSet
+            {
+                private int _useCount;
+                private static int SequenceNumber;
+
+                public TokenSet()
+                {
+                    var number = Interlocked.Increment(ref SequenceNumber);
+
+                    AccessToken = $"AT-{number}";
+                    RefreshToken = $"RT-{number}";
+                }
+
+                public string AccessToken { get; }
+                public string RefreshToken { get; }
+                public int AccessTokenUseCount => Interlocked.Increment(ref _useCount);
+            }
+
+            public bool IsValid(string accessToken)
+            {
+                if (_tokens.TryPeek(out var currentTokens))
+                {
+                    if (currentTokens.AccessToken != accessToken)
+                        return false;
+
+                    var expired = currentTokens.AccessTokenUseCount > _maxCallsPerAccessToken;
+
+                    return !expired;
+                }
+
+                return false;
+            }
+
+            internal TokenSet RefreshUsing(string refreshToken)
+            {
+                if (_tokens.TryPeek(out var currentTokens) && currentTokens.RefreshToken == refreshToken)
+                {
+                    var newTokens = new TokenSet();
+                    _tokens.Push(newTokens);
+                    return newTokens;
+                }
+
+                return null;
+            }
+        }
+
+        private class TestServer : DelegatingHandler
+        {
+            private readonly TestTokens _tokens;
+
+            public TestServer(TestTokens tokens)
+            {
+                _tokens = tokens;
+            }
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request,
+                CancellationToken cancellationToken)
+            {
+                var accessToken = request.Headers.Authorization?.Parameter;
+
+                var responseCode = _tokens.IsValid(accessToken)
+                    ? HttpStatusCode.OK
+                    : HttpStatusCode.Unauthorized;
+
+                return Task.FromResult(new HttpResponseMessage(responseCode));
+            }
+        }
+
+        private class TestableOidcTokenRefreshClient : OidcClient
+        {
+            private readonly TestTokens _tokens;
+
+            public TestableOidcTokenRefreshClient(TestTokens tokens) : base(new OidcClientOptions
+            {
+                Authority = "http://test-authority"
+            })
+            {
+                _tokens = tokens;
+            }
+
+            public override Task<RefreshTokenResult> RefreshTokenAsync(string refreshToken,
+                Parameters backChannelParameters = null,
+                CancellationToken cancellationToken = default)
+            {
+                var newTokens = _tokens.RefreshUsing(refreshToken);
+
+                RefreshTokenResult result;
+
+                if (newTokens == null)
+                    result = new RefreshTokenResult {Error = "something with grant"};
+                else
+                    result = new RefreshTokenResult
+                    {
+                        AccessToken = newTokens.AccessToken,
+                        RefreshToken = newTokens.RefreshToken
+                    };
+
+                return Task.FromResult(result);
+            }
+        }
+    }
+}

--- a/test/OidcClient.Tests/RefreshTokenDelegatingHandlerTests.cs
+++ b/test/OidcClient.Tests/RefreshTokenDelegatingHandlerTests.cs
@@ -78,7 +78,7 @@ namespace IdentityModel.OidcClient.Tests
                 await Task.WhenAll(tasks);
             }
 
-            tokens.Count.Should().BeGreaterThan(logicalThreadCount * callsPerThread / maxCallsPerAccessToken);
+            tokens.Count.Should().BeGreaterOrEqualTo(logicalThreadCount * callsPerThread / maxCallsPerAccessToken);
         }
 
         private class TestClient : IDisposable

--- a/test/OidcClient.Tests/RefreshTokenDelegatingHandlerTests.cs
+++ b/test/OidcClient.Tests/RefreshTokenDelegatingHandlerTests.cs
@@ -81,38 +81,6 @@ namespace IdentityModel.OidcClient.Tests
             tokens.Count.Should().BeGreaterThan(logicalThreadCount * callsPerThread / maxCallsPerAccessToken);
         }
 
-        [Fact]
-        public async Task Can_refresh_access_tokens_in_parallel_using_non_singleton_handler()
-        {
-            RefreshTokenDelegatingHandler CreateHandler(TestTokens testTokens)
-            {
-                return new RefreshTokenDelegatingHandler(
-                    new TestableOidcTokenRefreshClient(testTokens, 20.Milliseconds()),
-                    testTokens.InitialAccessToken,
-                    testTokens.InitialRefreshToken,
-                    new TestServer(testTokens, 0.Milliseconds()));
-            }
-
-            var logicalThreadCount = 2;
-            var callsPerThread = 20;
-            var maxCallsPerAccessToken = 10;
-
-            var tokens = new TestTokens(maxCallsPerAccessToken, _writeLine);
-
-            async Task PerformPingRequests()
-            {
-                using (var client = new TestClient(CreateHandler(tokens)))
-                    for (var i = 0; i < callsPerThread; i++)
-                        await client.SecuredPing();
-            }
-
-            var tasks = Enumerable.Range(0, logicalThreadCount).Select(i => PerformPingRequests());
-
-            await Task.WhenAll(tasks);
-
-            tokens.Count.Should().BeGreaterThan(logicalThreadCount * callsPerThread / maxCallsPerAccessToken);
-        }
-
         private class TestClient : IDisposable
         {
             private readonly HttpClient _client;


### PR DESCRIPTION
You can reproduce the race condition using the tests in commit 599f810.
The last commit (21c8f1c) fixes the race condition.

The race condition only occurs when using refresh tokens with sliding expiration.
Because for these refresh tokens, the refresh token gets immediately invalidated when another thread uses the refresh token to get a new access token.