### PR TITLE
ValidateHash support for 384 and 512 bit hashing algorithms

### DIFF
--- a/src/OidcClient/CryptoHelper.cs
+++ b/src/OidcClient/CryptoHelper.cs
@@ -56,10 +56,9 @@ namespace IdentityModel.OidcClient
             using (hashAlgorithm)
             {
                 var hash = hashAlgorithm.ComputeHash(Encoding.ASCII.GetBytes(data));
-                var size = (hashAlgorithm.HashSize / 8) / 2;
-
-                byte[] leftPart = new byte[hashAlgorithm.HashSize / size];
-                Array.Copy(hash, leftPart, hashAlgorithm.HashSize / size);
+                
+                byte[] leftPart = new byte[hashAlgorithm.HashSize / 16];
+                Array.Copy(hash, leftPart, hashAlgorithm.HashSize / 16);
 
                 var leftPartB64 = Base64Url.Encode(leftPart);
                 var match = leftPartB64.Equals(hashedData);


### PR DESCRIPTION
ValidateHash would always return false when validating tokens from an Identity Server 4 that has any of the following algorithms: RS384, RS512, PS384, PS512, ES384, ES512.
Using a static 16 for size seems to resolve the issue.