### PR TITLE
Fixed a bug that throws NullReferenceException in jwks debug log output.

### DIFF
--- a/src/OidcClient/OidcClient.cs
+++ b/src/OidcClient/OidcClient.cs
@@ -412,7 +412,11 @@ namespace IdentityModel.OidcClient
 
                 _logger.LogDebug("Successfully loaded discovery document");
                 _logger.LogDebug("Loaded keyset from {jwks_uri}", disco.JwksUri);
-                _logger.LogDebug("Keyset contains the following kids: {kids}", from k in disco.KeySet.Keys select k.Kid ?? "unspecified");
+                var kids = disco.KeySet?.Keys?.Select(k => k.Kid);
+                if (kids != null)
+                {
+                    _logger.LogDebug($"Keyset contains the following kids: {string.Join(",", kids)}");
+                }
 
                 Options.ProviderInformation = new ProviderInformation
                 {


### PR DESCRIPTION
Fixed a bug that throws NullReferenceException in jwks debug log output.
The above problem occurs when the RequireKeySet of the discovery policy is specified as false and the discovery endpoint where jwks_uri does not exist is accessed.