### PR TITLE
CLSCompliance

### DIFF
--- a/src/OidcClient/AssemblyAttributes.cs
+++ b/src/OidcClient/AssemblyAttributes.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
+using System;
 using System.Runtime.CompilerServices;
 
+[assembly: CLSCompliant(true)]
 [assembly: InternalsVisibleTo("OidcClient.Tests, PublicKey = 00240000048000009400000006020000002400005253413100040000010001008b4800109486e0cc76fda47b4467e7f3d9e18c2f59233ed35ab7d1000a38a73e436d73a20d02dbcc124ce63a8d93b9a4efb48c0ca922b3a9888d2757d7eb95e4217f3df14fdd393b03f93876777bcb57c824f20c3bb4e9580ed5a54c09d33295d23b096399b8fa32f6201a1062b8b6796b608c79df0ce733350b8dc3a7b7a6cb")]

--- a/src/OidcClient/OidcClient.cs
+++ b/src/OidcClient/OidcClient.cs
@@ -104,6 +104,7 @@ namespace IdentityModel.OidcClient
         /// <param name="frontChannelParameters">extra parameters to send to the authorize endpoint.</param>
         /// /// <param name="cancellationToken">A token that can be used to cancel the request</param>
         /// <returns>State for initiating the authorize request and processing the response</returns>
+        [CLSCompliant(false)]
         public virtual async Task<AuthorizeState> PrepareLoginAsync(Parameters frontChannelParameters = null, CancellationToken cancellationToken = default)
         {
             _logger.LogTrace("PrepareLoginAsync");
@@ -171,6 +172,7 @@ namespace IdentityModel.OidcClient
         /// <returns>
         /// Result of the login response validation
         /// </returns>
+        [CLSCompliant(false)]
         public virtual async Task<LoginResult> ProcessResponseAsync(
             string data, 
             AuthorizeState state, 
@@ -316,6 +318,7 @@ namespace IdentityModel.OidcClient
         /// <returns>
         /// A token response.
         /// </returns>
+        [CLSCompliant(false)]
         public virtual async Task<RefreshTokenResult> RefreshTokenAsync(
             string refreshToken, 
             Parameters backChannelParameters = null, 

--- a/src/OidcClient/OidcClientOptions.cs
+++ b/src/OidcClient/OidcClientOptions.cs
@@ -55,6 +55,7 @@ namespace IdentityModel.OidcClient
         /// <value>
         /// The client assertion.
         /// </value>
+        [CLSCompliant(false)]
         public ClientAssertion ClientAssertion { get; set; } = new ClientAssertion();
 
         /// <summary>
@@ -178,6 +179,7 @@ namespace IdentityModel.OidcClient
         /// <value>
         /// The token client authentication style.
         /// </value>
+        [CLSCompliant(false)]
         public ClientCredentialStyle TokenClientCredentialStyle { get; set; } = ClientCredentialStyle.PostBody;
 
         /// <summary>

--- a/src/OidcClient/Policy.cs
+++ b/src/OidcClient/Policy.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
-
-using IdentityModel.Client;
+using System;
 using System.Collections.Generic;
+using IdentityModel.Client;
 
 namespace IdentityModel.OidcClient
 {
@@ -18,6 +18,7 @@ namespace IdentityModel.OidcClient
         /// <value>
         /// The discovery.
         /// </value>
+        [CLSCompliant(false)]
         public DiscoveryPolicy Discovery { get; set; } = new DiscoveryPolicy();
 
         /// <summary>

--- a/src/OidcClient/ProviderInformation.cs
+++ b/src/OidcClient/ProviderInformation.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
-
+using System;
 using System.Collections.Generic;
 using IdentityModel.Jwk;
 
@@ -26,6 +26,7 @@ namespace IdentityModel.OidcClient
         /// <value>
         /// The key set.
         /// </value>
+        [CLSCompliant(false)]
         public JsonWebKeySet KeySet { get; set; }
 
         /// <summary>

--- a/src/OidcClient/Requests/LoginRequest.cs
+++ b/src/OidcClient/Requests/LoginRequest.cs
@@ -1,10 +1,9 @@
 ﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
-
-using IdentityModel.OidcClient.Browser;
-using System.Collections.Generic;
+using System;
 using IdentityModel.Client;
+using IdentityModel.OidcClient.Browser;
 
 namespace IdentityModel.OidcClient
 {
@@ -35,6 +34,7 @@ namespace IdentityModel.OidcClient
         /// <value>
         /// The extra parameters.
         /// </value>
+        [CLSCompliant(false)]
         public Parameters FrontChannelExtraParameters { get; set; } = new Parameters();
         
         /// <summary>
@@ -43,6 +43,7 @@ namespace IdentityModel.OidcClient
         /// <value>
         /// The extra parameters.
         /// </value>
+        [CLSCompliant(false)]
         public Parameters BackChannelExtraParameters { get; set; } = new Parameters();
     }
 }

--- a/src/OidcClient/Results/LoginResult.cs
+++ b/src/OidcClient/Results/LoginResult.cs
@@ -104,6 +104,7 @@ namespace IdentityModel.OidcClient
         /// <value>
         /// The token response from the server.
         /// </value>
+        [CLSCompliant(false)]
         public TokenResponse TokenResponse { get; internal set; }
     }
 }


### PR DESCRIPTION
I'm using IdentityModel.OidcClient in a number of other projects that re-expose OidcClient's types, but because the `IdentityModel.OidcClient` assembly isn't marked with `[assembly: CLSCompliant(true)]` I get peppered with warnings about CLS-compliance.

This PR adds `[assembly: CLSCompliant(true)]` as well as adds `[CLSCompliant(false)]`  for this library's re-exposed types imported from `IdentityModel` which too is not yet `CLSCompliant` - but if the maintainers would be willing to add `[assembly: CLSCompliant(true)]` to `IdentityModel` too then that makes the `false` attributes moot :)