### PR TITLE
Add ConfigureAwait(false) to all awaited tasks

### DIFF
--- a/src/OidcClient/AuthorizeClient.cs
+++ b/src/OidcClient/AuthorizeClient.cs
@@ -53,7 +53,7 @@ namespace IdentityModel.OidcClient
                 DisplayMode = request.DisplayMode
             };
 
-            var browserResult = await _options.Browser.InvokeAsync(browserOptions, cancellationToken);
+            var browserResult = await _options.Browser.InvokeAsync(browserOptions, cancellationToken).ConfigureAwait(false);
 
             if (browserResult.ResultType == BrowserResultType.Success)
             {
@@ -82,7 +82,7 @@ namespace IdentityModel.OidcClient
                 DisplayMode = request.BrowserDisplayMode
             };
 
-            return await _options.Browser.InvokeAsync(browserOptions, cancellationToken);
+            return await _options.Browser.InvokeAsync(browserOptions, cancellationToken).ConfigureAwait(false);
         }
 
         public AuthorizeState CreateAuthorizeState(Parameters frontChannelParameters)

--- a/src/OidcClient/OidcClient.cs
+++ b/src/OidcClient/OidcClient.cs
@@ -70,14 +70,14 @@ namespace IdentityModel.OidcClient
 
             if (request == null) request = new LoginRequest();
 
-            await EnsureConfigurationAsync(cancellationToken);
+            await EnsureConfigurationAsync(cancellationToken).ConfigureAwait(false);
 
             var authorizeResult = await _authorizeClient.AuthorizeAsync(new AuthorizeRequest
             {
                 DisplayMode = request.BrowserDisplayMode,
                 Timeout = request.BrowserTimeout,
                 ExtraParameters = request.FrontChannelExtraParameters
-            }, cancellationToken);
+            }, cancellationToken).ConfigureAwait(false);
 
             if (authorizeResult.IsError)
             {
@@ -88,7 +88,7 @@ namespace IdentityModel.OidcClient
                 authorizeResult.Data,
                 authorizeResult.State,
                 request.BackChannelExtraParameters,
-                cancellationToken);
+                cancellationToken).ConfigureAwait(false);
 
             if (!result.IsError)
             {
@@ -108,7 +108,7 @@ namespace IdentityModel.OidcClient
         {
             _logger.LogTrace("PrepareLoginAsync");
 
-            await EnsureConfigurationAsync(cancellationToken);
+            await EnsureConfigurationAsync(cancellationToken).ConfigureAwait(false);
             return _authorizeClient.CreateAuthorizeState(frontChannelParameters);
         }
 
@@ -120,7 +120,7 @@ namespace IdentityModel.OidcClient
         /// <returns></returns>
         public virtual async Task<string> PrepareLogoutAsync(LogoutRequest request = default, CancellationToken cancellationToken = default)
         {
-            await EnsureConfigurationAsync(cancellationToken);
+            await EnsureConfigurationAsync(cancellationToken).ConfigureAwait(false);
 
             var endpoint = Options.ProviderInformation.EndSessionEndpoint;
             if (endpoint.IsMissing())
@@ -141,9 +141,9 @@ namespace IdentityModel.OidcClient
         {
             if (request == null) request = new LogoutRequest();
 
-            await EnsureConfigurationAsync(cancellationToken);
+            await EnsureConfigurationAsync(cancellationToken).ConfigureAwait(false);
 
-            var result = await _authorizeClient.EndSessionAsync(request, cancellationToken);
+            var result = await _authorizeClient.EndSessionAsync(request, cancellationToken).ConfigureAwait(false);
 
             if (result.ResultType != Browser.BrowserResultType.Success)
             {
@@ -181,7 +181,7 @@ namespace IdentityModel.OidcClient
             _logger.LogInformation("Processing response.");
 
             backChannelParameters = backChannelParameters ?? new Parameters();
-            await EnsureConfigurationAsync(cancellationToken);
+            await EnsureConfigurationAsync(cancellationToken).ConfigureAwait(false);
 
             _logger.LogDebug("Authorize response: {response}", data);
             var authorizeResponse = new AuthorizeResponse(data);
@@ -192,7 +192,7 @@ namespace IdentityModel.OidcClient
                 return new LoginResult(authorizeResponse.Error, authorizeResponse.ErrorDescription);
             }
 
-            var result = await _processor.ProcessResponseAsync(authorizeResponse, state, backChannelParameters, cancellationToken);
+            var result = await _processor.ProcessResponseAsync(authorizeResponse, state, backChannelParameters, cancellationToken).ConfigureAwait(false);
             if (result.IsError)
             {
                 _logger.LogError(result.Error);
@@ -202,7 +202,7 @@ namespace IdentityModel.OidcClient
             var userInfoClaims = Enumerable.Empty<Claim>();
             if (Options.LoadProfile)
             {
-                var userInfoResult = await GetUserInfoAsync(result.TokenResponse.AccessToken, cancellationToken);
+                var userInfoResult = await GetUserInfoAsync(result.TokenResponse.AccessToken, cancellationToken).ConfigureAwait(false);
                 if (userInfoResult.IsError)
                 {
                     var error = $"Error contacting userinfo endpoint: {userInfoResult.Error}";
@@ -281,7 +281,7 @@ namespace IdentityModel.OidcClient
         {
             _logger.LogTrace("GetUserInfoAsync");
 
-            await EnsureConfigurationAsync(cancellationToken);
+            await EnsureConfigurationAsync(cancellationToken).ConfigureAwait(false);
             if (accessToken.IsMissing()) throw new ArgumentNullException(nameof(accessToken));
             if (!Options.ProviderInformation.SupportsUserInfo) throw new InvalidOperationException("No userinfo endpoint specified");
 
@@ -323,7 +323,7 @@ namespace IdentityModel.OidcClient
         {
             _logger.LogTrace("RefreshTokenAsync");
 
-            await EnsureConfigurationAsync(cancellationToken);
+            await EnsureConfigurationAsync(cancellationToken).ConfigureAwait(false);
             backChannelParameters = backChannelParameters ?? new Parameters();
             
             var client = Options.CreateClient();
@@ -350,7 +350,7 @@ namespace IdentityModel.OidcClient
 
             // validate token response
             var validationResult = await _processor.ValidateTokenResponseAsync(response, null, requireIdentityToken: Options.Policy.RequireIdentityTokenOnRefreshTokenResponse,
-                cancellationToken: cancellationToken);
+                cancellationToken: cancellationToken).ConfigureAwait(false);
             if (validationResult.IsError)
             {
                 return new RefreshTokenResult { Error = validationResult.Error };
@@ -368,7 +368,7 @@ namespace IdentityModel.OidcClient
 
         internal async Task EnsureConfigurationAsync(CancellationToken cancellationToken)
         {
-            await EnsureProviderInformationAsync(cancellationToken);
+            await EnsureProviderInformationAsync(cancellationToken).ConfigureAwait(false);
 
             _logger.LogTrace("Effective options:");
             _logger.LogTrace(LogSerializer.Serialize(Options));

--- a/src/OidcClient/ResponseProcessor.cs
+++ b/src/OidcClient/ResponseProcessor.cs
@@ -58,7 +58,7 @@ namespace IdentityModel.OidcClient
                 return new ResponseValidationResult("Invalid state.");
             }
 
-            return await ProcessCodeFlowResponseAsync(authorizeResponse, state, backChannelParameters, cancellationToken);
+            return await ProcessCodeFlowResponseAsync(authorizeResponse, state, backChannelParameters, cancellationToken).ConfigureAwait(false);
         }
 
         private async Task<ResponseValidationResult> ProcessCodeFlowResponseAsync(
@@ -74,7 +74,7 @@ namespace IdentityModel.OidcClient
             //////////////////////////////////////////////////////
 
             // redeem code for tokens
-            var tokenResponse = await RedeemCodeAsync(authorizeResponse.Code, state, backChannelParameters, cancellationToken);
+            var tokenResponse = await RedeemCodeAsync(authorizeResponse.Code, state, backChannelParameters, cancellationToken).ConfigureAwait(false);
             if (tokenResponse.IsError)
             {
                 return new ResponseValidationResult($"Error redeeming code: {tokenResponse.Error ?? "no error code"} / {tokenResponse.ErrorDescription ?? "no description"}");
@@ -85,7 +85,7 @@ namespace IdentityModel.OidcClient
             }
 
             // validate token response
-            var tokenResponseValidationResult = await ValidateTokenResponseAsync(tokenResponse, state, requireIdentityToken:false, cancellationToken: cancellationToken);
+            var tokenResponseValidationResult = await ValidateTokenResponseAsync(tokenResponse, state, requireIdentityToken:false, cancellationToken: cancellationToken).ConfigureAwait(false);
             if (tokenResponseValidationResult.IsError)
             {
                 return new ResponseValidationResult($"Error validating token response: {tokenResponseValidationResult.Error}");
@@ -137,12 +137,12 @@ namespace IdentityModel.OidcClient
                     validator = _options.IdentityTokenValidator;
                 }
                 
-                var validationResult = await validator.ValidateAsync(response.IdentityToken, _options, cancellationToken);
+                var validationResult = await validator.ValidateAsync(response.IdentityToken, _options, cancellationToken).ConfigureAwait(false);
 
                 if (validationResult.Error == "invalid_signature")
                 {
-                    await _refreshKeysAsync(cancellationToken);
-                    validationResult = await _options.IdentityTokenValidator.ValidateAsync(response.IdentityToken, _options, cancellationToken);
+                    await _refreshKeysAsync(cancellationToken).ConfigureAwait(false);
+                    validationResult = await _options.IdentityTokenValidator.ValidateAsync(response.IdentityToken, _options, cancellationToken).ConfigureAwait(false);
                 }
                 
                 if (validationResult.IsError)


### PR DESCRIPTION
Resolves #362.

While checking usage of `ConfigureAwait(false)` I found IdentityModel/IdentityModel/pull/206, but since it was for WebGL, and `ConfigureAwait(false)` was already used in some places, I guess it's not relevant here.