### PR TITLE
Added Identity Token to TokenRefreshEventArgs

### DIFF
--- a/src/OidcClient/RefreshTokenDelegatingHandler.cs
+++ b/src/OidcClient/RefreshTokenDelegatingHandler.cs
@@ -180,7 +180,7 @@ namespace IdentityModel.OidcClient
                             {
                                 try
                                 {
-                                    del(this, new TokenRefreshedEventArgs(response.AccessToken, response.RefreshToken, (int)response.ExpiresIn));
+                                    del(this, new TokenRefreshedEventArgs(response.AccessToken, response.RefreshToken, response.IdentityToken, response.ExpiresIn));
                                 }
                                 catch { }
                             }

--- a/src/OidcClient/RefreshTokenDelegatingHandler.cs
+++ b/src/OidcClient/RefreshTokenDelegatingHandler.cs
@@ -180,7 +180,7 @@ namespace IdentityModel.OidcClient
                             {
                                 try
                                 {
-                                    del(this, new TokenRefreshedEventArgs(response.AccessToken, response.RefreshToken, response.IdentityToken, response.ExpiresIn));
+                                    del(this, new TokenRefreshedEventArgs(response.AccessToken, response.RefreshToken, response.ExpiresIn, response.IdentityToken));
                                 }
                                 catch { }
                             }

--- a/src/OidcClient/TokenRefreshedEventArgs.cs
+++ b/src/OidcClient/TokenRefreshedEventArgs.cs
@@ -17,10 +17,11 @@ namespace IdentityModel.OidcClient
         /// <param name="accessToken">The access token.</param>
         /// <param name="refreshToken">The refresh token.</param>
         /// <param name="expiresIn">The expires in.</param>
-        public TokenRefreshedEventArgs(string accessToken, string refreshToken, int expiresIn)
+        public TokenRefreshedEventArgs(string accessToken, string refreshToken, string identityToken, int expiresIn)
         {
             AccessToken = accessToken;
             RefreshToken = refreshToken;
+            IdentityToken = identityToken;
             ExpiresIn = expiresIn;
         }
 
@@ -39,6 +40,14 @@ namespace IdentityModel.OidcClient
         /// The refresh token.
         /// </value>
         public string RefreshToken { get; }
+
+        /// <summary>
+        /// Gets the identity token.
+        /// </summary>
+        /// <value>
+        /// The identity token.
+        /// </value>
+        public string IdentityToken { get; }
 
         /// <summary>
         /// Gets or sets the expires in.

--- a/src/OidcClient/TokenRefreshedEventArgs.cs
+++ b/src/OidcClient/TokenRefreshedEventArgs.cs
@@ -17,12 +17,12 @@ namespace IdentityModel.OidcClient
         /// <param name="accessToken">The access token.</param>
         /// <param name="refreshToken">The refresh token.</param>
         /// <param name="expiresIn">The expires in.</param>
-        public TokenRefreshedEventArgs(string accessToken, string refreshToken, string identityToken, int expiresIn)
+        public TokenRefreshedEventArgs(string accessToken, string refreshToken, int expiresIn, string identityToken = null)
         {
             AccessToken = accessToken;
             RefreshToken = refreshToken;
-            IdentityToken = identityToken;
             ExpiresIn = expiresIn;
+            IdentityToken = identityToken;
         }
 
         /// <summary>
@@ -42,19 +42,19 @@ namespace IdentityModel.OidcClient
         public string RefreshToken { get; }
 
         /// <summary>
-        /// Gets the identity token.
-        /// </summary>
-        /// <value>
-        /// The identity token.
-        /// </value>
-        public string IdentityToken { get; }
-
-        /// <summary>
         /// Gets or sets the expires in.
         /// </summary>
         /// <value>
         /// The expires in.
         /// </value>
         public int ExpiresIn { get; }
+
+        /// <summary>
+        /// Gets the identity token.
+        /// </summary>
+        /// <value>
+        /// The identity token.
+        /// </value>
+        public string IdentityToken { get; }
     }
 }


### PR DESCRIPTION
This change allows updating the identity token cached at the client with the latest identity token coming from token renewal.

The motivation for this change is that claims can change during the runtime of the identity client (in my case, it's user claims related to permissions).

The alternative approach would be to call `/userinfo` endpoint, which we consider an avoidable overhead.