### PR TITLE
(Fix warning) Added missing annotation for new param in TokenRefreshedEventArgs

### DIFF
--- a/src/OidcClient/RefreshTokenDelegatingHandler.cs
+++ b/src/OidcClient/RefreshTokenDelegatingHandler.cs
@@ -180,7 +180,7 @@ namespace IdentityModel.OidcClient
                             {
                                 try
                                 {
-                                    del(this, new TokenRefreshedEventArgs(response.AccessToken, response.RefreshToken, (int)response.ExpiresIn));
+                                    del(this, new TokenRefreshedEventArgs(response.AccessToken, response.RefreshToken, response.IdentityToken, response.ExpiresIn));
                                 }
                                 catch { }
                             }

--- a/src/OidcClient/RefreshTokenDelegatingHandler.cs
+++ b/src/OidcClient/RefreshTokenDelegatingHandler.cs
@@ -180,7 +180,7 @@ namespace IdentityModel.OidcClient
                             {
                                 try
                                 {
-                                    del(this, new TokenRefreshedEventArgs(response.AccessToken, response.RefreshToken, response.IdentityToken, response.ExpiresIn));
+                                    del(this, new TokenRefreshedEventArgs(response.AccessToken, response.RefreshToken, response.ExpiresIn, response.IdentityToken));
                                 }
                                 catch { }
                             }

--- a/src/OidcClient/TokenRefreshedEventArgs.cs
+++ b/src/OidcClient/TokenRefreshedEventArgs.cs
@@ -17,10 +17,11 @@ namespace IdentityModel.OidcClient
         /// <param name="accessToken">The access token.</param>
         /// <param name="refreshToken">The refresh token.</param>
         /// <param name="expiresIn">The expires in.</param>
-        public TokenRefreshedEventArgs(string accessToken, string refreshToken, int expiresIn)
+        public TokenRefreshedEventArgs(string accessToken, string refreshToken, string identityToken, int expiresIn)
         {
             AccessToken = accessToken;
             RefreshToken = refreshToken;
+            IdentityToken = identityToken;
             ExpiresIn = expiresIn;
         }
 
@@ -39,6 +40,14 @@ namespace IdentityModel.OidcClient
         /// The refresh token.
         /// </value>
         public string RefreshToken { get; }
+
+        /// <summary>
+        /// Gets the identity token.
+        /// </summary>
+        /// <value>
+        /// The identity token.
+        /// </value>
+        public string IdentityToken { get; }
 
         /// <summary>
         /// Gets or sets the expires in.

--- a/src/OidcClient/TokenRefreshedEventArgs.cs
+++ b/src/OidcClient/TokenRefreshedEventArgs.cs
@@ -17,6 +17,7 @@ namespace IdentityModel.OidcClient
         /// <param name="accessToken">The access token.</param>
         /// <param name="refreshToken">The refresh token.</param>
         /// <param name="expiresIn">The expires in.</param>
+        /// <param name="identityToken">The identity token (optional).</param>
         public TokenRefreshedEventArgs(string accessToken, string refreshToken, int expiresIn, string identityToken = null)
         {
             AccessToken = accessToken;

--- a/src/OidcClient/TokenRefreshedEventArgs.cs
+++ b/src/OidcClient/TokenRefreshedEventArgs.cs
@@ -17,12 +17,12 @@ namespace IdentityModel.OidcClient
         /// <param name="accessToken">The access token.</param>
         /// <param name="refreshToken">The refresh token.</param>
         /// <param name="expiresIn">The expires in.</param>
-        public TokenRefreshedEventArgs(string accessToken, string refreshToken, string identityToken, int expiresIn)
+        public TokenRefreshedEventArgs(string accessToken, string refreshToken, int expiresIn, string identityToken = null)
         {
             AccessToken = accessToken;
             RefreshToken = refreshToken;
-            IdentityToken = identityToken;
             ExpiresIn = expiresIn;
+            IdentityToken = identityToken;
         }
 
         /// <summary>
@@ -42,19 +42,19 @@ namespace IdentityModel.OidcClient
         public string RefreshToken { get; }
 
         /// <summary>
-        /// Gets the identity token.
-        /// </summary>
-        /// <value>
-        /// The identity token.
-        /// </value>
-        public string IdentityToken { get; }
-
-        /// <summary>
         /// Gets or sets the expires in.
         /// </summary>
         /// <value>
         /// The expires in.
         /// </value>
         public int ExpiresIn { get; }
+
+        /// <summary>
+        /// Gets the identity token.
+        /// </summary>
+        /// <value>
+        /// The identity token.
+        /// </value>
+        public string IdentityToken { get; }
     }
 }


### PR DESCRIPTION
This PR aims to fix the following warnings:
![image](https://user-images.githubusercontent.com/32511760/194851750-51a444a7-aac7-4fd8-8de6-a3eb47d279ed.png)


@leastprivilege when can I expect these new changes to be published into a new version (especially [the previous PR](https://github.com/IdentityModel/IdentityModel.OidcClient/pull/367#issuecomment-1273077436) that contains necessary changes to my integration with your OIDC package)