### PR TITLE
Enable Trimmable Assembly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,13 @@ jobs:
     steps:
     - uses: actions/checkout@af513c7a016048ae468971c52ed77d9562c7c819
 
-    - name: Setup net6
+    - name: Setup dotnet
       uses: actions/setup-dotnet@v1
       with:
-          dotnet-version: '6.0.x'
+        dotnet-version: |
+          6.0.x
+          7.0.x
+          8.0.x
 
     - run: dotnet --info
     

--- a/IdentityModel.OidcClient.sln
+++ b/IdentityModel.OidcClient.sln
@@ -25,6 +25,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DPoPTests", "test\DPoPTests
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ConsoleClientWithBrowserAndDPoP", "clients\ConsoleClientWithBrowserAndDPoP\ConsoleClientWithBrowserAndDPoP.csproj", "{7DDDA872-49C0-43F0-8B88-2531BF828DDE}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TrimmableAnalysis", "test\TrimmableAnalysis\TrimmableAnalysis.csproj", "{672FE4E9-9071-4C59-95FC-F265DF6B2FF5}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -63,6 +65,10 @@ Global
 		{7DDDA872-49C0-43F0-8B88-2531BF828DDE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7DDDA872-49C0-43F0-8B88-2531BF828DDE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7DDDA872-49C0-43F0-8B88-2531BF828DDE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{672FE4E9-9071-4C59-95FC-F265DF6B2FF5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{672FE4E9-9071-4C59-95FC-F265DF6B2FF5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{672FE4E9-9071-4C59-95FC-F265DF6B2FF5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{672FE4E9-9071-4C59-95FC-F265DF6B2FF5}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -76,6 +82,7 @@ Global
 		{56EC3A58-33FE-4DCD-9D64-2A985DC58C2C} = {0B7CC363-CF34-4B40-A769-7E928A6B25AF}
 		{0E1807AF-4142-4A3D-925C-BBA019E4E777} = {3DEB81D4-5B40-4D20-AC50-66D1CD6EA24A}
 		{7DDDA872-49C0-43F0-8B88-2531BF828DDE} = {A4154BEB-4B4A-4A48-B75D-B52432304F36}
+		{672FE4E9-9071-4C59-95FC-F265DF6B2FF5} = {3DEB81D4-5B40-4D20-AC50-66D1CD6EA24A}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {66951C2E-691F-408C-9283-F2455F390A9A}

--- a/build/Program.cs
+++ b/build/Program.cs
@@ -21,6 +21,7 @@ namespace build
             public const string Pack = "pack";
             public const string SignBinary = "sign-binary";
             public const string SignPackage = "sign-package";
+            public const string TrimmableAnalysis = "trimmable-analysis";
         }
 
         static async Task Main(string[] args)
@@ -65,9 +66,14 @@ namespace build
                 SignNuGet();
             });
 
-            Target("default", DependsOn(Targets.Test, Targets.Pack));
+            Target(Targets.TrimmableAnalysis, () =>
+            {
+                Run("dotnet", "publish test/TrimmableAnalysis -c Release -r win-x64");
+            });
 
-            Target("sign", DependsOn(Targets.Test, Targets.SignPackage));
+            Target("default", DependsOn(Targets.Test, Targets.Pack, Targets.TrimmableAnalysis));
+
+            Target("sign", DependsOn(Targets.Test, Targets.SignPackage, Targets.TrimmableAnalysis));
 
             await RunTargetsAndExitAsync(args, ex => ex is SimpleExec.ExitCodeException || ex.Message.EndsWith(envVarMissing));
         }

--- a/src/DPoP/DPoP.csproj
+++ b/src/DPoP/DPoP.csproj
@@ -39,7 +39,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="IdentityModel" Version="6.1.0" />
+        <PackageReference Include="IdentityModel" Version="6.2.0" />
         <PackageReference Include="minver" Version="4.3.0" PrivateAssets="All" />
         <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.30.0" />
 

--- a/src/OidcClient/IIdentityTokenValidator.cs
+++ b/src/OidcClient/IIdentityTokenValidator.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using IdentityModel.OidcClient.Results;

--- a/src/OidcClient/IIdentityTokenValidator.cs
+++ b/src/OidcClient/IIdentityTokenValidator.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using IdentityModel.OidcClient.Results;

--- a/src/OidcClient/Infrastructure/LogSerializer.cs
+++ b/src/OidcClient/Infrastructure/LogSerializer.cs
@@ -3,9 +3,7 @@
 
 using System.Text.Json;
 using System.Text.Json.Serialization;
-#if NET5_0_OR_GREATER
 using System.Text.Json.Serialization.Metadata;
-#endif
 
 namespace IdentityModel.OidcClient.Infrastructure
 {
@@ -21,9 +19,11 @@ namespace IdentityModel.OidcClient.Infrastructure
         public static bool Enabled = true;
 
         static readonly JsonSerializerOptions JsonOptions = new JsonSerializerOptions()
-        {
-            IgnoreNullValues = true,
-            WriteIndented = true
+		{
+#pragma warning disable SYSLIB0020 // Type or member is obsolete
+			IgnoreNullValues = true,
+#pragma warning restore SYSLIB0020 // Type or member is obsolete
+			WriteIndented = true
         };
 
         static LogSerializer()
@@ -38,11 +38,9 @@ namespace IdentityModel.OidcClient.Infrastructure
         /// <returns></returns>
         public static string Serialize<T>(T logObject)
         {
-#if NET5_0_OR_GREATER
-            return Enabled ? JsonSerializer.Serialize(logObject, (JsonTypeInfo<T>)SourceGenerationContext.Default.GetTypeInfo(typeof(T))) : "Logging has been disabled";
-#else
-            return Enabled ? JsonSerializer.Serialize(logObject, JsonOptions) : "Logging has been disabled";
-#endif
+            return Enabled ?
+                JsonSerializer.Serialize(logObject, (JsonTypeInfo<T>)SourceGenerationContext.Default.GetTypeInfo(typeof(T))) :
+                "Logging has been disabled";
 		}
     }
 }

--- a/src/OidcClient/Infrastructure/LogSerializer.cs
+++ b/src/OidcClient/Infrastructure/LogSerializer.cs
@@ -1,9 +1,11 @@
 ﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
-
 using System.Text.Json;
 using System.Text.Json.Serialization;
+#if NET5_0_OR_GREATER
+using System.Text.Json.Serialization.Metadata;
+#endif
 
 namespace IdentityModel.OidcClient.Infrastructure
 {
@@ -34,9 +36,13 @@ namespace IdentityModel.OidcClient.Infrastructure
         /// </summary>
         /// <param name="logObject">The object.</param>
         /// <returns></returns>
-        public static string Serialize(object logObject)
+        public static string Serialize<T>(T logObject)
         {
+#if NET5_0_OR_GREATER
+            return Enabled ? JsonSerializer.Serialize(logObject, (JsonTypeInfo<T>)SourceGenerationContext.Default.GetTypeInfo(typeof(T))) : "Logging has been disabled";
+#else
             return Enabled ? JsonSerializer.Serialize(logObject, JsonOptions) : "Logging has been disabled";
-        }
+#endif
+		}
     }
 }

--- a/src/OidcClient/Infrastructure/LogSerializer.cs
+++ b/src/OidcClient/Infrastructure/LogSerializer.cs
@@ -1,6 +1,10 @@
 ﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
+#if NET6_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
+
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Text.Json.Serialization.Metadata;
@@ -34,7 +38,23 @@ namespace IdentityModel.OidcClient.Infrastructure
         /// </summary>
         /// <param name="logObject">The object.</param>
         /// <returns></returns>
-        public static string Serialize<T>(T logObject)
+#if NET6_0_OR_GREATER
+       [RequiresUnreferencedCode("The log serializer uses reflection in a way that is incompatible with trimming")]
+#endif
+        public static string Serialize(object logObject)
+        {
+            return Enabled ? JsonSerializer.Serialize(logObject, JsonOptions) : "Logging has been disabled";
+        }
+
+        internal static string Serialize(OidcClientOptions opts) => Serialize<OidcClientOptions>(opts);
+        internal static string Serialize(AuthorizeState state) => Serialize<AuthorizeState>(state);
+
+        /// <summary>
+        /// Serializes the specified object.
+        /// </summary>
+        /// <param name="logObject">The object.</param>
+        /// <returns></returns>
+        private static string Serialize<T>(T logObject)
         {
             return Enabled ?
                 JsonSerializer.Serialize(logObject, (JsonTypeInfo<T>)SourceGenerationContext.Default.GetTypeInfo(typeof(T))) :

--- a/src/OidcClient/Infrastructure/LogSerializer.cs
+++ b/src/OidcClient/Infrastructure/LogSerializer.cs
@@ -14,7 +14,7 @@ namespace IdentityModel.OidcClient.Infrastructure
     {
         /// <summary>
         /// Allows log serialization to be disabled, for example, for platforms
-        /// that don't support serialization of arbitarary objects to JSON.
+        /// that don't support serialization of arbitrary objects to JSON.
         /// </summary>
         public static bool Enabled = true;
 

--- a/src/OidcClient/NoValidationIdentityTokenValidator.cs
+++ b/src/OidcClient/NoValidationIdentityTokenValidator.cs
@@ -27,12 +27,8 @@ namespace IdentityModel.OidcClient
             }
 
             var payload = Encoding.UTF8.GetString((Base64Url.Decode(parts[1])));
-#if NET5_0_OR_GREATER
-            var values = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(
+            var values = JsonSerializer.Deserialize(
                 payload, SourceGenerationContext.Default.DictionaryStringJsonElement);
-#else
-            var values = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(payload);
-#endif
 
             var claims = new List<Claim>();
             foreach (var element in values)

--- a/src/OidcClient/NoValidationIdentityTokenValidator.cs
+++ b/src/OidcClient/NoValidationIdentityTokenValidator.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Security.Claims;
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 using IdentityModel.OidcClient.Results;
@@ -26,10 +27,13 @@ namespace IdentityModel.OidcClient
             }
 
             var payload = Encoding.UTF8.GetString((Base64Url.Decode(parts[1])));
+#if NET5_0_OR_GREATER
+            var values = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(
+                payload, SourceGenerationContext.Default.DictionaryStringJsonElement);
+#else
+            var values = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(payload);
+#endif
 
-            var values =
-                JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(payload);
-            
             var claims = new List<Claim>();
             foreach (var element in values)
             {
@@ -43,7 +47,6 @@ namespace IdentityModel.OidcClient
                 else
                 {
                     claims.Add(new Claim(element.Key, element.Value.ToString()));
-                    
                 }
             }
 

--- a/src/OidcClient/OidcClient.csproj
+++ b/src/OidcClient/OidcClient.csproj
@@ -26,7 +26,7 @@
     <DebugType>embedded</DebugType>
 
     <!-- Enable Trimming Warnings to allow consumers to publish as trimmed -->
-    <IsTrimmable>true</IsTrimmable>
+    <IsTrimmable Condition="'$(TargetFramework)' == 'net6.0'">true</IsTrimmable>
 
     <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">True</ContinuousIntegrationBuild>
 

--- a/src/OidcClient/OidcClient.csproj
+++ b/src/OidcClient/OidcClient.csproj
@@ -40,7 +40,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="IdentityModel" Version="6.0.0" />
+    <PackageReference Include="IdentityModel" Version="6.2.0" />
     <PackageReference Include="minver" Version="4.3.0" PrivateAssets="All" />
     
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />

--- a/src/OidcClient/OidcClient.csproj
+++ b/src/OidcClient/OidcClient.csproj
@@ -6,6 +6,7 @@
     <AssemblyName>IdentityModel.OidcClient</AssemblyName>
 
     <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
 
     <PackageTags>OAuth2;OAuth 2.0;OpenID Connect;Security;Identity;IdentityServer</PackageTags>
     <Description>RFC8252 compliant and certified OpenID Connect and OAuth 2.0 client library for native applications</Description>
@@ -41,9 +42,17 @@
   <ItemGroup>
     <PackageReference Include="IdentityModel" Version="5.2.0" />
     <PackageReference Include="minver" Version="3.0.0-alpha.1" PrivateAssets="All" />
-    
+
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
+
+  <!--Conditional Package references -->
+  <ItemGroup Condition="'$(TargetFramework)' != 'net6.0'">
+    <PackageReference Include="System.Text.Json" Version="6.0.8" />
+
+    <!--Force older version to prevent incompatible references -->
+    <PackageReference Include="System.Text.Encodings.Web" Version="6.0.0" /> 
+  </ItemGroup>   
 
 </Project>

--- a/src/OidcClient/OidcClient.csproj
+++ b/src/OidcClient/OidcClient.csproj
@@ -4,14 +4,14 @@
     <PackageId>IdentityModel.OidcClient</PackageId>
     <RootNamespace>IdentityModel.OidcClient</RootNamespace>
     <AssemblyName>IdentityModel.OidcClient</AssemblyName>
-    
-    <TargetFramework>netstandard2.0</TargetFramework>
-    
+
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+
     <PackageTags>OAuth2;OAuth 2.0;OpenID Connect;Security;Identity;IdentityServer</PackageTags>
     <Description>RFC8252 compliant and certified OpenID Connect and OAuth 2.0 client library for native applications</Description>
     <Authors>Dominick Baier;Brock Allen</Authors>
     <PackageIcon>icon.jpg</PackageIcon>
-    
+
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
 
@@ -24,12 +24,14 @@
     <!-- Recommended: Embed symbols containing Source Link in the main file (exe/dll) -->
     <DebugType>embedded</DebugType>
 
+    <!-- Enable Trimming Warnings to allow consumers to publish as trimmed -->
+    <IsTrimmable>true</IsTrimmable>
+
     <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">True</ContinuousIntegrationBuild>
-    
+
     <AssemblyOriginatorKeyFile>../../key.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition="'$(OS)' != 'Windows_NT'">true</PublicSign>
-    
   </PropertyGroup>
 
    <ItemGroup>

--- a/src/OidcClient/ResponseProcessor.cs
+++ b/src/OidcClient/ResponseProcessor.cs
@@ -1,15 +1,12 @@
 ﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
-
 using IdentityModel.Client;
 using IdentityModel.OidcClient.Infrastructure;
 using IdentityModel.OidcClient.Results;
 using Microsoft.Extensions.Logging;
 using System;
-using System.Collections.Generic;
 using System.Net;
-using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/src/OidcClient/SourceGenerationContext.cs
+++ b/src/OidcClient/SourceGenerationContext.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace IdentityModel.OidcClient
+{
+#if NET5_0_OR_GREATER
+    [JsonSourceGenerationOptions(
+        WriteIndented = false,
+        PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+        GenerationMode = JsonSourceGenerationMode.Metadata)]
+    [JsonSerializable(typeof(AuthorizeState))]
+    [JsonSerializable(typeof(Dictionary<string, JsonElement>))]
+    [JsonSerializable(typeof(OidcClientOptions))]
+    internal partial class SourceGenerationContext : JsonSerializerContext
+    {
+    }
+#endif
+}

--- a/src/OidcClient/SourceGenerationContext.cs
+++ b/src/OidcClient/SourceGenerationContext.cs
@@ -4,16 +4,15 @@ using System.Text.Json.Serialization;
 
 namespace IdentityModel.OidcClient
 {
-#if NET5_0_OR_GREATER
     [JsonSourceGenerationOptions(
         WriteIndented = false,
         PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
-        GenerationMode = JsonSourceGenerationMode.Metadata)]
+        GenerationMode = JsonSourceGenerationMode.Metadata,
+	    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonSerializable(typeof(AuthorizeState))]
     [JsonSerializable(typeof(Dictionary<string, JsonElement>))]
     [JsonSerializable(typeof(OidcClientOptions))]
     internal partial class SourceGenerationContext : JsonSerializerContext
     {
     }
-#endif
 }

--- a/test/DPoPTests/DPoPTests.csproj
+++ b/test/DPoPTests/DPoPTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net7.0;net8.0</TargetFramework>
+        <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/test/DPoPTests/DPoPTests.csproj
+++ b/test/DPoPTests/DPoPTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFrameworks>net6.0;net7.0;net8.0</TargetFramework>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/test/JwtValidationTests/JwtValidationTests.csproj
+++ b/test/JwtValidationTests/JwtValidationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net7.0;net8.0</TargetFramework>
+        <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/test/JwtValidationTests/JwtValidationTests.csproj
+++ b/test/JwtValidationTests/JwtValidationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFrameworks>net6.0;net7.0;net8.0</TargetFramework>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/test/OidcClient.Tests/LogSerializerTests.cs
+++ b/test/OidcClient.Tests/LogSerializerTests.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using FluentAssertions;
+using System;
+using Xunit;
+using IdentityModel.OidcClient.Infrastructure;
+
+namespace IdentityModel.OidcClient.Tests
+{
+    public class LogSerializerTests
+    {
+        [Fact]
+        // This test exists to make sure that the public api for the log
+        // serializer can serialize types that aren't part of the source
+        // generation context. There is an internal api that does use the source
+        // generation context types. We should always use that other serialize
+        // method internally in order to be trimmable. The overload in this test
+        // exists to avoid a breaking change. 
+        public void LogSerializer_should_serialize_arbitrary_types()
+        {
+            // We instantiate the test class as an example of a class that is
+            // not (and won't ever be) in the generation context.
+            var act = () => LogSerializer.Serialize(new LogSerializerTests());
+            act.Should().NotThrow<Exception>();
+        }
+    }
+}

--- a/test/TrimmableAnalysis/Program.cs
+++ b/test/TrimmableAnalysis/Program.cs
@@ -1,0 +1,2 @@
+﻿// See https://aka.ms/new-console-template for more information
+Console.WriteLine("Hello, World!");

--- a/test/TrimmableAnalysis/README.md
+++ b/test/TrimmableAnalysis/README.md
@@ -1,0 +1,3 @@
+This project exists to facilitate analysis of trimmable warnings. 
+
+See https://learn.microsoft.com/en-us/dotnet/core/deploying/trimming/prepare-libraries-for-trimming

--- a/test/TrimmableAnalysis/TrimmableAnalysis.csproj
+++ b/test/TrimmableAnalysis/TrimmableAnalysis.csproj
@@ -6,11 +6,12 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <PublishTrimmed>true</PublishTrimmed>
     <TrimmerSingleWarn>false</TrimmerSingleWarn> 
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors> 
   </PropertyGroup>
 
   <ItemGroup>
     <TrimmerRootAssembly Include="IdentityModel.OidcClient" />
-    <ProjectReference Include="..\..\src\OidcClient\OidcClient.csproj" /> 
-  </ItemGroup>
+    <ProjectReference Include="..\..\src\OidcClient\OidcClient.csproj" />
+   </ItemGroup>
 
 </Project>

--- a/test/TrimmableAnalysis/TrimmableAnalysis.csproj
+++ b/test/TrimmableAnalysis/TrimmableAnalysis.csproj
@@ -1,0 +1,16 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <PublishTrimmed>true</PublishTrimmed>
+    <TrimmerSingleWarn>false</TrimmerSingleWarn> 
+  </PropertyGroup>
+
+  <ItemGroup>
+    <TrimmerRootAssembly Include="IdentityModel.OidcClient" />
+    <ProjectReference Include="..\..\src\OidcClient\OidcClient.csproj" /> 
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
With this change I am annotating the core assembly as IsTrimmable. This enables warnings for any known issues that may arise when publishing a final project as trimmed. The only warnings present were the use of runtime reflection code to perform the Json serialization. I converted over to using the Json Source Generator to move this logic from runtime to compile time (a net performance win too).

fixes #390 