### PR TITLE
Fill ErrorDescription property in AuthorizeAsync for AuthorizeResult.

### DIFF
--- a/src/OidcClient/AuthorizeClient.cs
+++ b/src/OidcClient/AuthorizeClient.cs
@@ -62,6 +62,7 @@ namespace IdentityModel.OidcClient
             }
 
             result.Error = browserResult.Error ?? browserResult.ResultType.ToString();
+            result.ErrorDescription = browserResult.ErrorDescription;
             return result;
         }
 

--- a/test/OidcClient.Tests/AuthorizeRequestTests.cs
+++ b/test/OidcClient.Tests/AuthorizeRequestTests.cs
@@ -89,7 +89,8 @@ namespace IdentityModel.OidcClient.Tests
                 Browser = new TestBrowser(_ => Task.FromResult(new BrowserResult
                 {
                     ResultType = BrowserResultType.HttpError,
-                    Error = "Something terrible happened"
+                    Error = "Something terrible happened",
+                    ErrorDescription = "Explaining the terrible error..."
                 }))
             };
 
@@ -98,6 +99,7 @@ namespace IdentityModel.OidcClient.Tests
             var response = await client.AuthorizeAsync(new AuthorizeRequest());
 
             response.Error.Should().Be("Something terrible happened");
+            response.ErrorDescription.Should().Be("Explaining the terrible error...");
         }
     }
 }


### PR DESCRIPTION
Fixes an issue with LoginResult.ErrorDescription:
When setting the ErrorDescription Property of the return value in IBrowser.InvokeAsync, the return value of OidcClient.LoginAsync does not contain this value.