### PR TITLE
Update dependencies

### DIFF
--- a/src/DPoP/DPoP.csproj
+++ b/src/DPoP/DPoP.csproj
@@ -43,7 +43,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="IdentityModel" Version="7.0.0-preview.3" />
+        <PackageReference Include="IdentityModel" Version="7.0.0-preview.4" />
         <PackageReference Include="minver" Version="4.3.0" PrivateAssets="All" />
         <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.3.1" />
 

--- a/src/DPoP/DPoP.csproj
+++ b/src/DPoP/DPoP.csproj
@@ -5,7 +5,7 @@
         <RootNamespace>IdentityModel.OidcClient.DPoP</RootNamespace>
         <AssemblyName>IdentityModel.OidcClient.DPoP</AssemblyName>
 
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
         <LangVersion>latest</LangVersion>
 		<Nullable>enable</Nullable>
 

--- a/src/OidcClient/OidcClient.csproj
+++ b/src/OidcClient/OidcClient.csproj
@@ -42,7 +42,7 @@
 </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="IdentityModel" Version="7.0.0-preview.3" />
+    <PackageReference Include="IdentityModel" Version="7.0.0-preview.4" />
     <PackageReference Include="minver" Version="4.3.0" PrivateAssets="All" />
     
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
@@ -51,10 +51,7 @@
 
   <!--Conditional Package references -->
   <ItemGroup Condition="'$(TargetFramework)' != 'net6.0'">
-    <PackageReference Include="System.Text.Json" Version="6.0.8" />
-
-    <!--Force older version to prevent incompatible references -->
-    <PackageReference Include="System.Text.Encodings.Web" Version="6.0.0" /> 
+    <PackageReference Include="System.Text.Json" Version="8.0.0" />
   </ItemGroup>   
 
 </Project>


### PR DESCRIPTION
- [Update to latest IdentityModel preview](https://github.com/IdentityModel/IdentityModel.OidcClient/commit/3b62a008787158275db490c8690a588fa8743c75)
- [Add dotnet core as a target framework](https://github.com/IdentityModel/IdentityModel.OidcClient/commit/17c502abef27f63691deb4164a4754f6bebf8310): This avoids some dependency issues, since IdentityModel targets both netstandard and net6.0. In the IM netstandard build, we include the System.Text.Json dependency explicitly. In the IM net6.0 build, we don't, because that's built in. This would cause an issue if an application targeted net6.0 and depended on OidcClient. If OidcClient only targets netstandard, then when it depends on IM, we get the  netstandard build of IM, and bring along the System.Text.Json dependency.