### PR TITLE
Set correct ClientCredentialStyle for use with ClientAssertion

### DIFF
--- a/src/OidcClient/AuthorizeClient.cs
+++ b/src/OidcClient/AuthorizeClient.cs
@@ -141,10 +141,14 @@ namespace IdentityModel.OidcClient
                 ClientSecret = _options.ClientSecret,
                 ClientAssertion = await _options.GetClientAssertionAsync(),
 
-                ClientCredentialStyle = ClientCredentialStyle.PostBody,
 
                 Parameters = CreateAuthorizeParameters(state, codeChallenge, frontChannelParameters),
             };
+
+            if(par.ClientAssertion?.Value != null)
+            {
+                par.ClientCredentialStyle = ClientCredentialStyle.PostBody;
+            }
 
             return await http.PushAuthorizationAsync(par);
         }

--- a/src/OidcClient/AuthorizeClient.cs
+++ b/src/OidcClient/AuthorizeClient.cs
@@ -140,8 +140,6 @@ namespace IdentityModel.OidcClient
                 
                 ClientSecret = _options.ClientSecret,
                 ClientAssertion = await _options.GetClientAssertionAsync(),
-
-
                 Parameters = CreateAuthorizeParameters(state, codeChallenge, frontChannelParameters),
             };
 

--- a/src/OidcClient/AuthorizeClient.cs
+++ b/src/OidcClient/AuthorizeClient.cs
@@ -140,7 +140,9 @@ namespace IdentityModel.OidcClient
                 
                 ClientSecret = _options.ClientSecret,
                 ClientAssertion = await _options.GetClientAssertionAsync(),
-                
+
+                ClientCredentialStyle = ClientCredentialStyle.PostBody,
+
                 Parameters = CreateAuthorizeParameters(state, codeChallenge, frontChannelParameters),
             };
 


### PR DESCRIPTION
The bug can be reproduced by running https://github.com/IdentityModel/IdentityModel.OidcClient/tree/main/clients/ConsoleClientWithBrowser