### PR TITLE
Check for DPoPNonce with case-insensitive TryGetValues method

### DIFF
--- a/src/DPoP/DPoPExtensions.cs
+++ b/src/DPoP/DPoPExtensions.cs
@@ -27,10 +27,8 @@ public static class DPoPExtensions
     /// </summary>
     public static string? GetDPoPNonce(this HttpResponseMessage response)
     {
-        var nonce = response.Headers
-            .FirstOrDefault(x => x.Key == OidcConstants.HttpHeaders.DPoPNonce)
-            .Value?.FirstOrDefault();
-        return nonce;
+        response.Headers.TryGetValues(OidcConstants.HttpHeaders.DPoPNonce, out var headers);
+        return headers?.FirstOrDefault() ?? string.Empty;
     }
 
     ///// <summary>


### PR DESCRIPTION
When checking for "DPoP-Nonce," this method checks against the Key value in the headers and uses a string comparison. This can fail because that header, like any other, can be case-insensitive, leading to issues where it can't get the value properly even though it is in the response.

`TryGetValues` will search for headers regardless of the case. Switching to that here, this method will work in all _cases_ (pardon the pun, it took me hours of debugging to figure out this is what was broken, lol).