### PR TITLE
Fix trimming warnings when publishing with Native AOT

### DIFF
--- a/src/DPoP/DPoP.csproj
+++ b/src/DPoP/DPoP.csproj
@@ -27,8 +27,9 @@
         <DebugType>embedded</DebugType>
 
         <!-- Enable Trimming Warnings to allow consumers to publish as trimmed -->
-        <IsTrimmable Condition="'$(TargetFramework)' == 'net6.0'">true</IsTrimmable>
-
+        <IsTrimmable Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">true</IsTrimmable>
+        <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">true</IsAotCompatible>
+        
         <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">True</ContinuousIntegrationBuild>
 
         <AssemblyOriginatorKeyFile>../../key.snk</AssemblyOriginatorKeyFile>

--- a/src/IdentityTokenValidator/IdentityTokenValidator.csproj
+++ b/src/IdentityTokenValidator/IdentityTokenValidator.csproj
@@ -4,7 +4,7 @@
         <RootNamespace>IdentityModel.OidcClient</RootNamespace>
         <AssemblyName>IdentityModel.OidcClient.IdentityTokenValidator</AssemblyName>
         
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
     
         <PackageTags>OAuth2;OAuth 2.0;OpenID Connect;Security;Identity;IdentityServer</PackageTags>
         <Description>Identity token validator for IdentityModeo.OidcClient based on the Microsoft JWT handler</Description>
@@ -24,8 +24,9 @@
         <DebugType>embedded</DebugType>
 
         <!-- Enable Trimming Warnings to allow consumers to publish as trimmed -->
-        <IsTrimmable Condition="'$(TargetFramework)' == 'net6.0'">true</IsTrimmable>
-
+        <IsTrimmable Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">true</IsTrimmable>
+        <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">true</IsAotCompatible>
+        
         <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">True</ContinuousIntegrationBuild>
         
         <AssemblyOriginatorKeyFile>../../key.snk</AssemblyOriginatorKeyFile>

--- a/src/OidcClient/Infrastructure/LogSerializer.cs
+++ b/src/OidcClient/Infrastructure/LogSerializer.cs
@@ -28,6 +28,11 @@ namespace IdentityModel.OidcClient.Infrastructure
             WriteIndented = true
         };
 
+#if NET7_0_OR_GREATER
+        [UnconditionalSuppressMessage("AOT", 
+            "IL3050:Calling members annotated with 'RequiresDynamicCodeAttribute' may break functionality when AOT compiling.", 
+            Justification = "Code using `JsonOptions` is guarded by `RequiresDynamicCodeAttribute`")]
+#endif
         static LogSerializer()
         {
             JsonOptions.Converters.Add(new JsonStringEnumConverter());
@@ -39,7 +44,10 @@ namespace IdentityModel.OidcClient.Infrastructure
         /// <param name="logObject">The object.</param>
         /// <returns></returns>
 #if NET6_0_OR_GREATER
-       [RequiresUnreferencedCode("The log serializer uses reflection in a way that is incompatible with trimming")]
+        [RequiresUnreferencedCode("The log serializer uses reflection in a way that is incompatible with trimming")]
+#endif
+#if NET7_0_OR_GREATER
+        [RequiresDynamicCode("The log serializer uses reflection in a way that is incompatible with trimming")]
 #endif
         public static string Serialize(object logObject)
         {

--- a/src/OidcClient/OidcClient.csproj
+++ b/src/OidcClient/OidcClient.csproj
@@ -4,7 +4,7 @@
     <RootNamespace>IdentityModel.OidcClient</RootNamespace>
     <AssemblyName>IdentityModel.OidcClient</AssemblyName>
 
-    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
 
     <PackageId>IdentityModel.OidcClient</PackageId>
@@ -27,8 +27,9 @@
     <DebugType>embedded</DebugType>
 
     <!-- Enable Trimming Warnings to allow consumers to publish as trimmed -->
-    <IsTrimmable Condition="'$(TargetFramework)' == 'net6.0'">true</IsTrimmable>
-
+    <IsTrimmable Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">true</IsTrimmable>
+    <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">true</IsAotCompatible>
+    
     <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">True</ContinuousIntegrationBuild>
 
     <AssemblyOriginatorKeyFile>../../key.snk</AssemblyOriginatorKeyFile>
@@ -50,7 +51,7 @@
   </ItemGroup>
 
   <!--Conditional Package references -->
-  <ItemGroup Condition="'$(TargetFramework)' != 'net6.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Text.Json" Version="8.0.0" />
   </ItemGroup>   
 

--- a/test/TrimmableAnalysis/TrimmableAnalysis.csproj
+++ b/test/TrimmableAnalysis/TrimmableAnalysis.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
-    <PublishTrimmed>true</PublishTrimmed>
+    <PublishAot>true</PublishAot>
     <TrimmerSingleWarn>false</TrimmerSingleWarn> 
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <IsPackable>false</IsPackable>


### PR DESCRIPTION
This fixes the two AOT analysis warnings in this project

```
IdentityModel.OidcClient/src/OidcClient/Infrastructure/LogSerializer.cs(52): AOT analysis warning IL3050: IdentityModel.OidcClient.Infrastructure.LogSerializer.Serialize(Object): Using member 'System.Text.Json.JsonSerializer.Serialize<Object>(Object,JsonSerializerOptions)' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling. JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.
```

```
IdentityModel.OidcClient/src/OidcClient/Infrastructure/LogSerializer.cs(36): AOT analysis warning IL3050: IdentityModel.OidcClient.Infrastructure.LogSerializer..cctor(): Using member 'System.Text.Json.Serialization.JsonStringEnumConverter.JsonStringEnumConverter()' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling. JsonStringEnumConverter cannot be statically analyzed and requires runtime code generation. Applications should use the generic JsonStringEnumConverter<TEnum> instead.
```

When targetting net9.0 there are no errors. When targeting net8.0, there is one remaining error, which is tracked in the dotnet runtime by https://github.com/dotnet/runtime/issues/109958. 